### PR TITLE
Release: add private macOS publish workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Real mac publish workflow changes stay with release managers.
+.github/workflows/** @openclaw/openclaw-release-managers

--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -1,0 +1,350 @@
+name: OpenClaw macOS Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing OpenClaw release tag to package (for example v2026.3.22 or v2026.3.22-beta.1)
+        required: true
+        type: string
+      preflight_only:
+        description: Build, sign, notarize, and package only; skip uploading assets to the public GitHub release
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: openclaw-macos-publish-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.23.0"
+  OPENCLAW_REPOSITORY: openclaw/openclaw
+  SPARKLE_FEED_URL: https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-beta\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Require main workflow ref for real publish
+        if: ${{ !inputs.preflight_only }}
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "Real publish runs must be dispatched from main. Use preflight_only=true for branch validation."
+            exit 1
+          fi
+
+  build_sign_and_publish:
+    needs: prepare
+    runs-on: macos-latest-xlarge
+    environment: mac-release
+    permissions:
+      contents: read
+    steps:
+      - name: Mint GitHub App token for the public repo
+        id: public_repo_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OPENCLAW_PUBLIC_REPO_APP_ID }}
+          private-key: ${{ secrets.OPENCLAW_PUBLIC_REPO_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: openclaw
+
+      - name: Checkout selected public source tag
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.OPENCLAW_REPOSITORY }}
+          ref: refs/tags/${{ inputs.tag }}
+          token: ${{ steps.public_repo_token.outputs.token }}
+          path: source
+          fetch-depth: 0
+
+      - name: Checkout submodules (retry)
+        working-directory: source
+        run: |
+          set -euo pipefail
+          git submodule sync --recursive
+          for attempt in 1 2 3 4 5; do
+            if git -c protocol.version=2 submodule update --init --force --depth=1 --recursive; then
+              exit 0
+            fi
+            echo "Submodule update failed (attempt $attempt/5). Retrying..."
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: source
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile
+
+      - name: Select Xcode 26.1
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.1.app
+          xcodebuild -version
+          swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swiftpm-release-${{ hashFiles('source/apps/macos/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-release-
+
+      - name: Ensure matching public GitHub release exists
+        working-directory: source
+        env:
+          GH_TOKEN: ${{ steps.public_repo_token.outputs.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh release view "$RELEASE_TAG" --repo "$OPENCLAW_REPOSITORY" >/dev/null
+
+      - name: Validate release tag and package metadata
+        working-directory: source
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_MAIN_REF: origin/main
+        run: |
+          set -euo pipefail
+          RELEASE_SHA=$(git rev-parse HEAD)
+          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          pnpm release:openclaw:npm:check
+
+      - name: Resolve package version
+        id: package_version
+        working-directory: source
+        run: echo "value=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Determine release channel
+        id: release_channel
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" == *-beta.* ]]; then
+            echo "is_beta=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_beta=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check
+        working-directory: source
+        run: pnpm check
+
+      - name: Build
+        working-directory: source
+        run: pnpm build
+
+      - name: Build Control UI
+        working-directory: source
+        run: node scripts/ui.js build
+
+      - name: Verify release contents
+        working-directory: source
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: pnpm release:check
+
+      - name: Swift test
+        working-directory: source
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if swift test --package-path apps/macos --parallel; then
+              exit 0
+            fi
+            echo "swift test failed (attempt $attempt/3). Retrying..."
+            sleep $((attempt * 20))
+          done
+          exit 1
+
+      - name: Import Developer ID certificate
+        env:
+          MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/openclaw-macos-release.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/openclaw-release.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+          export CERT_PATH MACOS_DEVELOPER_ID_P12_BASE64
+          python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          Path(os.environ["CERT_PATH"]).write_bytes(
+              base64.b64decode(os.environ["MACOS_DEVELOPER_ID_P12_BASE64"])
+          )
+          PY
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$MACOS_DEVELOPER_ID_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          EXISTING_KEYCHAINS="$(security list-keychains -d user | tr -d '"')"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING_KEYCHAINS
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Resolve signing identity
+        run: |
+          set -euo pipefail
+          SIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" 2>/dev/null | awk -F'\"' '/Developer ID Application/ { print $2; exit }')"
+          if [[ -z "${SIGN_IDENTITY}" ]]; then
+            echo "Developer ID Application identity not found in imported keychain." >&2
+            exit 1
+          fi
+          echo "SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Write notary and Sparkle key files
+        env:
+          APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          NOTARYTOOL_KEY_PATH="$RUNNER_TEMP/openclaw-notary.p8"
+          SPARKLE_PRIVATE_KEY_PATH="$RUNNER_TEMP/openclaw-sparkle-ed25519.pem"
+          export NOTARYTOOL_KEY_PATH SPARKLE_PRIVATE_KEY_PATH
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          def write_secret(path_env: str, value_env: str) -> None:
+              value = os.environ[value_env].replace("\\n", "\n")
+              Path(os.environ[path_env]).write_text(value, encoding="utf-8")
+
+          write_secret("NOTARYTOOL_KEY_PATH", "APP_STORE_CONNECT_API_KEY_P8")
+          write_secret("SPARKLE_PRIVATE_KEY_PATH", "SPARKLE_PRIVATE_KEY")
+          PY
+          echo "NOTARYTOOL_KEY=$NOTARYTOOL_KEY_PATH" >> "$GITHUB_ENV"
+          echo "NOTARYTOOL_KEY_ID=$APP_STORE_CONNECT_KEY_ID" >> "$GITHUB_ENV"
+          echo "NOTARYTOOL_ISSUER=$APP_STORE_CONNECT_ISSUER_ID" >> "$GITHUB_ENV"
+          echo "SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Build, sign, notarize, and package macOS release
+        working-directory: source
+        env:
+          APP_VERSION: ${{ steps.package_version.outputs.value }}
+          BUNDLE_ID: ai.openclaw.mac
+          BUILD_CONFIG: release
+          SIGN_IDENTITY: ${{ env.SIGN_IDENTITY }}
+          SKIP_PNPM_INSTALL: "1"
+          SKIP_TSC: "1"
+          SKIP_UI_BUILD: "1"
+          SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
+        run: scripts/package-mac-dist.sh
+
+      - name: Checkout public main for stable appcast seed
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.OPENCLAW_REPOSITORY }}
+          ref: main
+          token: ${{ steps.public_repo_token.outputs.token }}
+          path: openclaw-main
+          fetch-depth: 1
+
+      - name: Seed appcast from public main
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        run: |
+          set -euo pipefail
+          APPCAST_SOURCE="openclaw-main/appcast.xml"
+          if [[ -f "$APPCAST_SOURCE" ]]; then
+            cp "$APPCAST_SOURCE" source/appcast.xml
+          else
+            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
+          fi
+
+      - name: Generate signed appcast artifact
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        working-directory: source
+        env:
+          SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
+          SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
+        run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
+
+      - name: Upload stable appcast artifact
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-appcast-${{ inputs.tag }}
+          path: source/appcast.xml
+          if-no-files-found: error
+
+      - name: Skip shared appcast for beta releases
+        if: ${{ steps.release_channel.outputs.is_beta == 'true' }}
+        run: echo "Beta release detected; skip shared production appcast artifact generation."
+
+      - name: Upload preflight macOS artifacts
+        if: ${{ inputs.preflight_only }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-preflight-${{ inputs.tag }}
+          path: |
+            source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
+            source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.dmg
+            source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.dSYM.zip
+          if-no-files-found: error
+
+      - name: Upload macOS assets to public GitHub release
+        if: ${{ !inputs.preflight_only }}
+        working-directory: source
+        env:
+          GH_TOKEN: ${{ steps.public_repo_token.outputs.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          VERSION: ${{ steps.package_version.outputs.value }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" \
+            "dist/OpenClaw-$VERSION.zip" \
+            "dist/OpenClaw-$VERSION.dmg" \
+            "dist/OpenClaw-$VERSION.dSYM.zip" \
+            --clobber \
+            --repo "$OPENCLAW_REPOSITORY"
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          if [[ -n "${KEYCHAIN_PATH:-}" ]]; then
+            security delete-keychain "$KEYCHAIN_PATH" >/dev/null 2>&1 || true
+          fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
 # releases-private
-Private macOS release workflows for OpenClaw
+
+Private release automation for OpenClaw's real macOS signing, notarization,
+Sparkle appcast generation, and GitHub release asset upload.
+
+The source of truth stays in `openclaw/openclaw`:
+
+- source code
+- git tags
+- GitHub releases
+- npm publish workflow
+- `appcast.xml` on `main`
+
+This repo exists so Apple signing, notarization, Sparkle signing, and the
+cross-repo upload token do not live in `openclaw/openclaw`.
+
+## Workflow
+
+- Real mac publish workflow:
+  `.github/workflows/openclaw-macos-publish.yml`
+- The workflow checks out `openclaw/openclaw` at `refs/tags/<tag>` and uses the
+  public repo's packaging scripts directly.
+- Stable releases upload a `macos-appcast-<tag>` artifact here, but the workflow
+  never pushes `appcast.xml` back to `main`.
+- After a successful stable publish, an agent or maintainer must download that
+  artifact and commit `appcast.xml` to `openclaw/openclaw` `main`.
+
+## Required `mac-release` environment secrets
+
+- `OPENCLAW_PUBLIC_REPO_APP_ID`
+- `OPENCLAW_PUBLIC_REPO_APP_PRIVATE_KEY`
+- `MACOS_DEVELOPER_ID_P12_BASE64`
+- `MACOS_DEVELOPER_ID_P12_PASSWORD`
+- `APP_STORE_CONNECT_API_KEY_P8`
+- `APP_STORE_CONNECT_KEY_ID`
+- `APP_STORE_CONNECT_ISSUER_ID`
+- `SPARKLE_PRIVATE_KEY`
+
+## GitHub App contract
+
+Install a GitHub App on `openclaw/openclaw` with the minimum permissions this
+workflow needs:
+
+- `contents: write`
+- `metadata: read`
+
+The workflow mints an installation token at runtime and uses that token for:
+
+- checking out `openclaw/openclaw`
+- reading `appcast.xml` from `main`
+- checking that the GitHub release for the tag already exists
+- uploading signed macOS assets to the existing GitHub release
+
+## Repo policy
+
+- Workflow changes are code-owned by `@openclaw/openclaw-release-managers`.
+- The `mac-release` environment exists and should hold all real publish secrets.
+- Real publish runs must be dispatched from this repo's `main` branch.
+
+## Pending platform protections
+
+Two GitHub settings could not be enabled through the API on this private repo
+with the current org plan:
+
+- branch protection on `main`
+- required reviewers on the `mac-release` environment
+
+When the billing plan supports them, enable:
+
+- branch protection for `main`
+- required reviewers on `mac-release`:
+  `@openclaw/openclaw-release-managers`
+- `prevent self-review` on `mac-release`
+- keep `can admins bypass` disabled on `mac-release`


### PR DESCRIPTION
## Summary

- add the private `openclaw-macos-publish.yml` workflow that checks out `openclaw/openclaw` by tag and performs the real macOS build, signing, notarization, appcast artifact generation, and release upload
- add workflow `CODEOWNERS` so `.github/workflows/**` stays owned by `@openclaw/openclaw-release-managers`
- document the required environment secrets, GitHub App contract, and the manual stable `appcast.xml` commit back to `openclaw/openclaw`
- capture the GitHub plan blockers that currently prevent private-repo branch protection and required-reviewer environment rules from being enabled

## Related

- public workflow PR: https://github.com/openclaw/openclaw/pull/53166
- maintainer docs PR: https://github.com/openclaw/maintainers/pull/30

## Notes

- repo created: `openclaw/releases-private`
- team access granted: `@openclaw/openclaw-release-managers`
- environment created: `mac-release` with `can_admins_bypass=false`
- GitHub rejected two desired protections on the current org plan:
  - branch protection on `main` returned `403`
  - required reviewers / `prevent self-review` on `mac-release` returned `422`

## Verification

- parsed `.github/workflows/openclaw-macos-publish.yml` with Ruby `YAML.load_file`
- verified the branch was pushed and the workflow file is present in the PR branch
