### PR TITLE
Release: remove private GitHub App dependency

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -115,13 +115,9 @@ jobs:
 
       - name: Ensure matching public GitHub release exists
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          curl -fsSL \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${OPENCLAW_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
-            >/dev/null
+        run: gh release view "$RELEASE_TAG" --repo "$OPENCLAW_REPOSITORY" >/dev/null
 
       - name: Validate release tag and package metadata
         working-directory: source

--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
 
 concurrency:
-  group: openclaw-macos-publish-${{ inputs.tag }}
+  group: openclaw-macos-publish-${{ contains(inputs.tag, '-beta.') && inputs.tag || 'stable-feed' }}
   cancel-in-progress: false
 
 env:
@@ -58,23 +58,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Mint GitHub App token for the public repo
-        id: public_repo_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OPENCLAW_PUBLIC_REPO_APP_ID }}
-          private-key: ${{ secrets.OPENCLAW_PUBLIC_REPO_APP_PRIVATE_KEY }}
-          owner: openclaw
-          repositories: openclaw
-
-      - name: Checkout selected public source tag
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.OPENCLAW_REPOSITORY }}
-          ref: refs/tags/${{ inputs.tag }}
-          token: ${{ steps.public_repo_token.outputs.token }}
-          path: source
-          fetch-depth: 0
+      - name: Clone selected public source tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          git clone --filter=blob:none https://github.com/openclaw/openclaw.git source
+          git -C source checkout --detach "refs/tags/${RELEASE_TAG}"
 
       - name: Checkout submodules (retry)
         working-directory: source
@@ -124,11 +114,14 @@ jobs:
             ${{ runner.os }}-swiftpm-release-
 
       - name: Ensure matching public GitHub release exists
-        working-directory: source
         env:
-          GH_TOKEN: ${{ steps.public_repo_token.outputs.token }}
           RELEASE_TAG: ${{ inputs.tag }}
-        run: gh release view "$RELEASE_TAG" --repo "$OPENCLAW_REPOSITORY" >/dev/null
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${OPENCLAW_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            >/dev/null
 
       - name: Validate release tag and package metadata
         working-directory: source
@@ -274,25 +267,15 @@ jobs:
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
         run: scripts/package-mac-dist.sh
 
-      - name: Checkout public main for stable appcast seed
-        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.OPENCLAW_REPOSITORY }}
-          ref: main
-          token: ${{ steps.public_repo_token.outputs.token }}
-          path: openclaw-main
-          fetch-depth: 1
-
       - name: Seed appcast from public main
         if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
         run: |
           set -euo pipefail
-          APPCAST_SOURCE="openclaw-main/appcast.xml"
-          if [[ -f "$APPCAST_SOURCE" ]]; then
-            cp "$APPCAST_SOURCE" source/appcast.xml
+          if curl -fsSL "$SPARKLE_FEED_URL" -o source/appcast.xml; then
+            echo "Seeded appcast from $SPARKLE_FEED_URL."
           else
-            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
+            rm -f source/appcast.xml
+            echo "No existing appcast at $SPARKLE_FEED_URL; generating a fresh feed."
           fi
 
       - name: Generate signed appcast artifact
@@ -302,6 +285,19 @@ jobs:
           SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
           SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
         run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
+
+      - name: Resolve packaged artifact name
+        id: packaged_artifacts
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
+        run: |
+          set -euo pipefail
+          if [[ "$PREFLIGHT_ONLY" == "true" ]]; then
+            echo "value=macos-preflight-${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=macos-release-${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload stable appcast artifact
         if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
@@ -315,32 +311,44 @@ jobs:
         if: ${{ steps.release_channel.outputs.is_beta == 'true' }}
         run: echo "Beta release detected; skip shared production appcast artifact generation."
 
-      - name: Upload preflight macOS artifacts
-        if: ${{ inputs.preflight_only }}
+      - name: Upload packaged macOS artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: macos-preflight-${{ inputs.tag }}
+          name: ${{ steps.packaged_artifacts.outputs.value }}
           path: |
             source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
             source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.dmg
             source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.dSYM.zip
           if-no-files-found: error
 
-      - name: Upload macOS assets to public GitHub release
-        if: ${{ !inputs.preflight_only }}
-        working-directory: source
+      - name: Summarize manual follow-up
         env:
-          GH_TOKEN: ${{ steps.public_repo_token.outputs.token }}
           RELEASE_TAG: ${{ inputs.tag }}
           VERSION: ${{ steps.package_version.outputs.value }}
+          ARTIFACT_NAME: ${{ steps.packaged_artifacts.outputs.value }}
+          PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
+          IS_BETA: ${{ steps.release_channel.outputs.is_beta }}
         run: |
           set -euo pipefail
-          gh release upload "$RELEASE_TAG" \
-            "dist/OpenClaw-$VERSION.zip" \
-            "dist/OpenClaw-$VERSION.dmg" \
-            "dist/OpenClaw-$VERSION.dSYM.zip" \
-            --clobber \
-            --repo "$OPENCLAW_REPOSITORY"
+          {
+            echo "## Private macOS workflow output"
+            echo
+            echo "- Packaged artifacts: \`${ARTIFACT_NAME}\`"
+            echo "- Version: \`${VERSION}\`"
+            echo
+            if [[ "$PREFLIGHT_ONLY" == "true" ]]; then
+              echo "This was a private preflight run. Inspect the packaged artifacts before any real publish run."
+            else
+              echo "This was a real private publish run. The workflow does not upload to the public GitHub release."
+              echo "An agent or maintainer must download \`${ARTIFACT_NAME}\` and upload the \`.zip\`, \`.dmg\`, and \`.dSYM.zip\` files to the existing release in \`${OPENCLAW_REPOSITORY}\`."
+            fi
+            echo
+            if [[ "$IS_BETA" != "true" ]]; then
+              echo "For stable releases, also download \`macos-appcast-${RELEASE_TAG}\` and commit \`appcast.xml\` back to \`main\` in \`${OPENCLAW_REPOSITORY}\`."
+            else
+              echo "Beta release detected; no shared production \`appcast.xml\` artifact is generated."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean up signing keychain
         if: always()

--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: false
         type: boolean
+      smoke_test_only:
+        description: Use ad-hoc packaging only; skip Apple signing, notarization, and shared appcast generation for workflow smoke tests
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: openclaw-macos-publish-${{ contains(inputs.tag, '-beta.') && inputs.tag || 'stable-feed' }}
@@ -50,6 +55,12 @@ jobs:
             echo "Real publish runs must be dispatched from main. Use preflight_only=true for branch validation."
             exit 1
           fi
+
+      - name: Forbid smoke-test mode on real publish
+        if: ${{ inputs.smoke_test_only && !inputs.preflight_only }}
+        run: |
+          echo "smoke_test_only=true is only valid with preflight_only=true."
+          exit 1
 
   build_sign_and_publish:
     needs: prepare
@@ -179,7 +190,24 @@ jobs:
           done
           exit 1
 
+      - name: Package macOS smoke-test artifacts
+        if: ${{ inputs.smoke_test_only }}
+        working-directory: source
+        env:
+          APP_VERSION: ${{ steps.package_version.outputs.value }}
+          ALLOW_ADHOC_SIGNING: "1"
+          BUNDLE_ID: ai.openclaw.mac
+          BUILD_CONFIG: release
+          CODESIGN_TIMESTAMP: "off"
+          SKIP_NOTARIZE: "1"
+          SKIP_PNPM_INSTALL: "1"
+          SKIP_TSC: "1"
+          SKIP_UI_BUILD: "1"
+          SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
+        run: scripts/package-mac-dist.sh
+
       - name: Import Developer ID certificate
+        if: ${{ !inputs.smoke_test_only }}
         env:
           MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
           MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
@@ -214,6 +242,7 @@ jobs:
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
       - name: Resolve signing identity
+        if: ${{ !inputs.smoke_test_only }}
         run: |
           set -euo pipefail
           SIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" 2>/dev/null | awk -F'\"' '/Developer ID Application/ { print $2; exit }')"
@@ -224,6 +253,7 @@ jobs:
           echo "SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
 
       - name: Write notary and Sparkle key files
+        if: ${{ !inputs.smoke_test_only }}
         env:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
@@ -251,6 +281,7 @@ jobs:
           echo "SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build, sign, notarize, and package macOS release
+        if: ${{ !inputs.smoke_test_only }}
         working-directory: source
         env:
           APP_VERSION: ${{ steps.package_version.outputs.value }}
@@ -264,7 +295,7 @@ jobs:
         run: scripts/package-mac-dist.sh
 
       - name: Seed appcast from public main
-        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        if: ${{ !inputs.smoke_test_only && steps.release_channel.outputs.is_beta != 'true' }}
         run: |
           set -euo pipefail
           if curl -fsSL "$SPARKLE_FEED_URL" -o source/appcast.xml; then
@@ -275,7 +306,7 @@ jobs:
           fi
 
       - name: Generate signed appcast artifact
-        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        if: ${{ !inputs.smoke_test_only && steps.release_channel.outputs.is_beta != 'true' }}
         working-directory: source
         env:
           SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
@@ -287,24 +318,31 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
+          SMOKE_TEST_ONLY: ${{ inputs.smoke_test_only }}
         run: |
           set -euo pipefail
-          if [[ "$PREFLIGHT_ONLY" == "true" ]]; then
+          if [[ "$SMOKE_TEST_ONLY" == "true" ]]; then
+            echo "value=macos-smoke-${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          elif [[ "$PREFLIGHT_ONLY" == "true" ]]; then
             echo "value=macos-preflight-${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "value=macos-release-${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload stable appcast artifact
-        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        if: ${{ !inputs.smoke_test_only && steps.release_channel.outputs.is_beta != 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: macos-appcast-${{ inputs.tag }}
           path: source/appcast.xml
           if-no-files-found: error
 
+      - name: Skip signed appcast for smoke tests
+        if: ${{ inputs.smoke_test_only }}
+        run: echo "Smoke-test mode enabled; skip shared production appcast artifact generation."
+
       - name: Skip shared appcast for beta releases
-        if: ${{ steps.release_channel.outputs.is_beta == 'true' }}
+        if: ${{ !inputs.smoke_test_only && steps.release_channel.outputs.is_beta == 'true' }}
         run: echo "Beta release detected; skip shared production appcast artifact generation."
 
       - name: Upload packaged macOS artifacts
@@ -323,6 +361,7 @@ jobs:
           VERSION: ${{ steps.package_version.outputs.value }}
           ARTIFACT_NAME: ${{ steps.packaged_artifacts.outputs.value }}
           PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
+          SMOKE_TEST_ONLY: ${{ inputs.smoke_test_only }}
           IS_BETA: ${{ steps.release_channel.outputs.is_beta }}
         run: |
           set -euo pipefail
@@ -332,14 +371,18 @@ jobs:
             echo "- Packaged artifacts: \`${ARTIFACT_NAME}\`"
             echo "- Version: \`${VERSION}\`"
             echo
-            if [[ "$PREFLIGHT_ONLY" == "true" ]]; then
+            if [[ "$SMOKE_TEST_ONLY" == "true" ]]; then
+              echo "This was a smoke-test run. Artifacts are ad-hoc signed, not notarized, and not suitable for release readiness."
+            elif [[ "$PREFLIGHT_ONLY" == "true" ]]; then
               echo "This was a private preflight run. Inspect the packaged artifacts before any real publish run."
             else
               echo "This was a real private publish run. The workflow does not upload to the public GitHub release."
               echo "An agent or maintainer must download \`${ARTIFACT_NAME}\` and upload the \`.zip\`, \`.dmg\`, and \`.dSYM.zip\` files to the existing release in \`${OPENCLAW_REPOSITORY}\`."
             fi
             echo
-            if [[ "$IS_BETA" != "true" ]]; then
+            if [[ "$SMOKE_TEST_ONLY" == "true" ]]; then
+              echo "Smoke-test mode skips shared production \`appcast.xml\` generation."
+            elif [[ "$IS_BETA" != "true" ]]; then
               echo "For stable releases, also download \`macos-appcast-${RELEASE_TAG}\` and commit \`appcast.xml\` back to \`main\` in \`${OPENCLAW_REPOSITORY}\`."
             else
               echo "Beta release detected; no shared production \`appcast.xml\` artifact is generated."

--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -145,7 +145,10 @@ jobs:
       - name: Resolve package version
         id: package_version
         working-directory: source
-        run: echo "value=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Determine release channel
         id: release_channel
@@ -329,6 +332,23 @@ jobs:
             echo "value=macos-release-${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve packaged file paths
+        id: packaged_files
+        working-directory: source
+        run: |
+          set -euo pipefail
+          ZIP_PATH="$(find dist -maxdepth 1 -type f -name 'OpenClaw-*.zip' ! -name '*.dSYM.zip' ! -name '*.notary.zip' -print | sort | tail -n 1)"
+          DMG_PATH="$(find dist -maxdepth 1 -type f -name 'OpenClaw-*.dmg' -print | sort | tail -n 1)"
+          DSYM_PATH="$(find dist -maxdepth 1 -type f -name 'OpenClaw-*.dSYM.zip' -print | sort | tail -n 1)"
+          if [[ -z "$ZIP_PATH" || -z "$DMG_PATH" || -z "$DSYM_PATH" ]]; then
+            echo "Missing packaged outputs in source/dist" >&2
+            ls -la dist >&2 || true
+            exit 1
+          fi
+          echo "zip=$ZIP_PATH" >> "$GITHUB_OUTPUT"
+          echo "dmg=$DMG_PATH" >> "$GITHUB_OUTPUT"
+          echo "dsym=$DSYM_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Upload stable appcast artifact
         if: ${{ !inputs.smoke_test_only && steps.release_channel.outputs.is_beta != 'true' }}
         uses: actions/upload-artifact@v7
@@ -350,9 +370,9 @@ jobs:
         with:
           name: ${{ steps.packaged_artifacts.outputs.value }}
           path: |
-            source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
-            source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.dmg
-            source/dist/OpenClaw-${{ steps.package_version.outputs.value }}.dSYM.zip
+            source/${{ steps.packaged_files.outputs.zip }}
+            source/${{ steps.packaged_files.outputs.dmg }}
+            source/${{ steps.packaged_files.outputs.dsym }}
           if-no-files-found: error
 
       - name: Summarize manual follow-up

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ live in `openclaw/openclaw`.
   An agent or maintainer must download `macos-release-<tag>` and upload the
   `.zip`, `.dmg`, and `.dSYM.zip` files to the existing release in
   `openclaw/openclaw`.
-- No GitHub App secret is required for the workflow anymore. Public repo reads
-  happen anonymously, and the public release upload happens outside Actions.
+- No GitHub App secret is required for the workflow anymore. Public source
+  checkout and appcast seeding happen without extra credentials, and the public
+  release upload happens outside Actions.
 - After a successful stable publish, an agent or maintainer must download that
   artifact and commit `appcast.xml` to `openclaw/openclaw` `main`.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ live in `openclaw/openclaw`.
 - The workflow checks out `openclaw/openclaw` at `refs/tags/<tag>` and uses the
   public repo's packaging scripts directly.
 - Every successful run uploads the packaged macOS artifacts to this workflow as
-  either `macos-preflight-<tag>` or `macos-release-<tag>`.
+  `macos-smoke-<tag>`, `macos-preflight-<tag>`, or `macos-release-<tag>`.
 - Stable releases upload a `macos-appcast-<tag>` artifact here, but the workflow
   never pushes `appcast.xml` back to `main`.
 - Real publish runs do not upload to the public GitHub release automatically.
@@ -31,6 +31,9 @@ live in `openclaw/openclaw`.
 - No GitHub App secret is required for the workflow anymore. Public source
   checkout and appcast seeding happen without extra credentials, and the public
   release upload happens outside Actions.
+- `smoke_test_only=true` is available for branch-safe workflow smoke tests. It
+  uses ad-hoc signing, skips notarization, skips shared appcast generation, and
+  does not require the Apple signing/notary/Sparkle secrets.
 - After a successful stable publish, an agent or maintainer must download that
   artifact and commit `appcast.xml` to `openclaw/openclaw` `main`.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # releases-private
 
 Private release automation for OpenClaw's real macOS signing, notarization,
-Sparkle appcast generation, and GitHub release asset upload.
+Sparkle appcast generation, and packaged release artifact generation.
 
 The source of truth stays in `openclaw/openclaw`:
 
@@ -11,8 +11,8 @@ The source of truth stays in `openclaw/openclaw`:
 - npm publish workflow
 - `appcast.xml` on `main`
 
-This repo exists so Apple signing, notarization, Sparkle signing, and the
-cross-repo upload token do not live in `openclaw/openclaw`.
+This repo exists so Apple signing, notarization, and Sparkle signing do not
+live in `openclaw/openclaw`.
 
 ## Workflow
 
@@ -20,36 +20,27 @@ cross-repo upload token do not live in `openclaw/openclaw`.
   `.github/workflows/openclaw-macos-publish.yml`
 - The workflow checks out `openclaw/openclaw` at `refs/tags/<tag>` and uses the
   public repo's packaging scripts directly.
+- Every successful run uploads the packaged macOS artifacts to this workflow as
+  either `macos-preflight-<tag>` or `macos-release-<tag>`.
 - Stable releases upload a `macos-appcast-<tag>` artifact here, but the workflow
   never pushes `appcast.xml` back to `main`.
+- Real publish runs do not upload to the public GitHub release automatically.
+  An agent or maintainer must download `macos-release-<tag>` and upload the
+  `.zip`, `.dmg`, and `.dSYM.zip` files to the existing release in
+  `openclaw/openclaw`.
+- No GitHub App secret is required for the workflow anymore. Public repo reads
+  happen anonymously, and the public release upload happens outside Actions.
 - After a successful stable publish, an agent or maintainer must download that
   artifact and commit `appcast.xml` to `openclaw/openclaw` `main`.
 
 ## Required `mac-release` environment secrets
 
-- `OPENCLAW_PUBLIC_REPO_APP_ID`
-- `OPENCLAW_PUBLIC_REPO_APP_PRIVATE_KEY`
 - `MACOS_DEVELOPER_ID_P12_BASE64`
 - `MACOS_DEVELOPER_ID_P12_PASSWORD`
 - `APP_STORE_CONNECT_API_KEY_P8`
 - `APP_STORE_CONNECT_KEY_ID`
 - `APP_STORE_CONNECT_ISSUER_ID`
 - `SPARKLE_PRIVATE_KEY`
-
-## GitHub App contract
-
-Install a GitHub App on `openclaw/openclaw` with the minimum permissions this
-workflow needs:
-
-- `contents: write`
-- `metadata: read`
-
-The workflow mints an installation token at runtime and uses that token for:
-
-- checking out `openclaw/openclaw`
-- reading `appcast.xml` from `main`
-- checking that the GitHub release for the tag already exists
-- uploading signed macOS assets to the existing GitHub release
 
 ## Repo policy
 


### PR DESCRIPTION
## Summary
- stop minting a GitHub App token in the private macOS workflow
- read the public openclaw repo without any added secret and always upload packaged artifacts to the private run
- document the new manual follow-up where the agent uploads release assets and commits stable appcast updates

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openclaw-macos-publish.yml"); puts "private yaml ok"'\n- git diff --check\n- branch workflow dispatch: https://github.com/openclaw/releases-private/actions/runs/23461809788\n\n## Follow-up\n- Apple signing/notary/Sparkle secrets are still required in the `mac-release` environment for the private workflow to complete\n- no GitHub App secret is required anymore