### PR TITLE
Release: expand private repo code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Real mac publish workflow changes stay with release managers.
-.github/workflows/** @openclaw/openclaw-release-managers
+# This private repo is release-manager-owned.
+* @openclaw/openclaw-release-managers


### PR DESCRIPTION
## Summary
- make the entire private repo code-owned by `@openclaw/openclaw-release-managers`
- keep the private release repo fully release-manager-owned

## Testing
- not run (CODEOWNERS-only change)