### PR TITLE
[codex] Add cross-OS release runtime checks workflow

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks.yml
@@ -1,0 +1,205 @@
+name: OpenClaw Cross-OS Release Checks
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Public OpenClaw ref to validate (tag, branch, or full commit SHA)
+        required: true
+        type: string
+      provider:
+        description: Provider lane to use for onboarding and the end-to-end turn
+        required: true
+        default: openai
+        type: choice
+        options:
+          - openai
+          - anthropic
+          - minimax
+      mode:
+        description: Which release-check lanes to run
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - fresh
+          - upgrade
+      previous_version:
+        description: Optional baseline version for the upgrade lane (defaults to npm latest)
+        required: false
+        type: string
+      ubuntu_runner:
+        description: Optional Linux runner label override
+        required: false
+        default: ""
+        type: string
+      windows_runner:
+        description: Optional Windows runner label override
+        required: false
+        default: ""
+        type: string
+      macos_runner:
+        description: Optional macOS runner label override
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: openclaw-cross-os-release-checks-${{ inputs.ref }}-${{ inputs.provider }}-${{ inputs.mode }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.32.1"
+  OPENCLAW_REPOSITORY: openclaw/openclaw
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - name: Validate provider secret availability
+        env:
+          PROVIDER: ${{ inputs.provider }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+        run: |
+          set -euo pipefail
+          case "${PROVIDER}" in
+            openai)
+              [[ -n "${OPENAI_API_KEY}" ]] || { echo "Missing OPENAI_API_KEY secret." >&2; exit 1; }
+              ;;
+            anthropic)
+              [[ -n "${ANTHROPIC_API_KEY}" ]] || { echo "Missing ANTHROPIC_API_KEY secret." >&2; exit 1; }
+              ;;
+            minimax)
+              [[ -n "${MINIMAX_API_KEY}" ]] || { echo "Missing MINIMAX_API_KEY secret." >&2; exit 1; }
+              ;;
+            *)
+              echo "Unsupported provider: ${PROVIDER}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Resolve runner matrix
+        id: matrix
+        env:
+          INPUT_UBUNTU_RUNNER: ${{ inputs.ubuntu_runner }}
+          INPUT_WINDOWS_RUNNER: ${{ inputs.windows_runner }}
+          INPUT_MACOS_RUNNER: ${{ inputs.macos_runner }}
+          VAR_UBUNTU_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_UBUNTU_RUNNER }}
+          VAR_WINDOWS_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_WINDOWS_RUNNER }}
+          VAR_MACOS_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_MACOS_RUNNER }}
+        run: |
+          node <<'NODE' >>"$GITHUB_OUTPUT"
+          const pick = (...values) => values.find((value) => typeof value === "string" && value.trim().length > 0)?.trim();
+          const matrix = {
+            include: [
+              {
+                os_id: "ubuntu",
+                display_name: "Linux",
+                runner: pick(process.env.INPUT_UBUNTU_RUNNER, process.env.VAR_UBUNTU_RUNNER, "ubuntu-latest"),
+                artifact_name: "linux",
+              },
+              {
+                os_id: "windows",
+                display_name: "Windows",
+                runner: pick(process.env.INPUT_WINDOWS_RUNNER, process.env.VAR_WINDOWS_RUNNER, "windows-latest"),
+                artifact_name: "windows",
+              },
+              {
+                os_id: "macos",
+                display_name: "macOS",
+                runner: pick(process.env.INPUT_MACOS_RUNNER, process.env.VAR_MACOS_RUNNER, "macos-latest-xlarge"),
+                artifact_name: "macos",
+              },
+            ],
+          };
+          process.stdout.write(`value=${JSON.stringify(matrix)}\n`);
+          NODE
+
+  cross_os_release_checks:
+    name: "${{ matrix.display_name }}"
+    needs: prepare
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    steps:
+      - name: Checkout private workflow repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout public source ref
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.OPENCLAW_REPOSITORY }}
+          ref: ${{ inputs.ref }}
+          path: source
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Run cross-OS release checks
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          OPENCLAW_RELEASE_CHECK_OS: ${{ matrix.os_id }}
+          OPENCLAW_RELEASE_CHECK_RUNNER: ${{ matrix.runner }}
+        run: |
+          node scripts/openclaw-cross-os-release-checks.mjs \
+            --source-dir source \
+            --provider "${{ inputs.provider }}" \
+            --mode "${{ inputs.mode }}" \
+            --output-dir "$RUNNER_TEMP/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}" \
+            ${{
+              inputs.previous_version != '' &&
+              format('--previous-version "{0}"', inputs.previous_version) ||
+              ''
+            }}
+
+      - name: Summarize release checks
+        if: always()
+        shell: bash
+        env:
+          SUMMARY_PATH: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}/summary.md
+        run: |
+          if [[ -f "${SUMMARY_PATH}" ]]; then
+            cat "${SUMMARY_PATH}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No summary generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload release-check artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-cross-os-release-checks-${{ matrix.artifact_name }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}
+          if-no-files-found: error

--- a/.github/workflows/openclaw-cross-os-release-checks.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks.yml
@@ -61,7 +61,11 @@ jobs:
     permissions:
       contents: read
     outputs:
+      baseline_spec: ${{ steps.baseline.outputs.value }}
+      candidate_file_name: ${{ steps.candidate_metadata.outputs.file_name }}
+      candidate_version: ${{ steps.candidate_metadata.outputs.version }}
       matrix: ${{ steps.matrix.outputs.value }}
+      source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
     steps:
       - name: Validate provider secret availability
         env:
@@ -86,6 +90,77 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Checkout private workflow repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout public source ref
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.OPENCLAW_REPOSITORY }}
+          ref: ${{ inputs.ref }}
+          path: source
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Build candidate artifact once
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare
+        run: |
+          node scripts/openclaw-cross-os-release-checks.mjs \
+            --prepare-only \
+            --source-dir source \
+            --output-dir "${OUTPUT_DIR}"
+
+      - name: Resolve baseline package spec
+        id: baseline
+        env:
+          INPUT_PREVIOUS_VERSION: ${{ inputs.previous_version }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_PREVIOUS_VERSION}" ]]; then
+            echo "value=openclaw@${INPUT_PREVIOUS_VERSION}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BASELINE_VERSION="$(npm view openclaw@latest version)"
+          echo "value=openclaw@${BASELINE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Capture candidate metadata
+        id: candidate_metadata
+        env:
+          CANDIDATE_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json
+        run: |
+          node <<'NODE' >>"$GITHUB_OUTPUT"
+          const fs = require("node:fs");
+          const payload = JSON.parse(fs.readFileSync(process.env.CANDIDATE_JSON, "utf8"));
+          process.stdout.write(`file_name=${payload.candidateFileName}\n`);
+          process.stdout.write(`version=${payload.candidateVersion}\n`);
+          process.stdout.write(`source_sha=${payload.sourceSha}\n`);
+          NODE
+
+      - name: Upload candidate artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package/${{ steps.candidate_metadata.outputs.file_name }}
+          if-no-files-found: error
 
       - name: Resolve runner matrix
         id: matrix
@@ -141,28 +216,16 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Checkout public source ref
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.OPENCLAW_REPOSITORY }}
-          ref: ${{ inputs.ref }}
-          path: source
-          fetch-depth: 0
-          persist-credentials: false
-          submodules: recursive
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Download candidate artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/candidate
 
       - name: Run cross-OS release checks
         shell: bash
@@ -174,15 +237,13 @@ jobs:
           OPENCLAW_RELEASE_CHECK_RUNNER: ${{ matrix.runner }}
         run: |
           node scripts/openclaw-cross-os-release-checks.mjs \
-            --source-dir source \
+            --candidate-tgz "$RUNNER_TEMP/openclaw-cross-os-release-checks/candidate/${{ needs.prepare.outputs.candidate_file_name }}" \
+            --candidate-version "${{ needs.prepare.outputs.candidate_version }}" \
+            --source-sha "${{ needs.prepare.outputs.source_sha }}" \
+            --baseline-spec "${{ needs.prepare.outputs.baseline_spec }}" \
             --provider "${{ inputs.provider }}" \
             --mode "${{ inputs.mode }}" \
-            --output-dir "$RUNNER_TEMP/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}" \
-            ${{
-              inputs.previous_version != '' &&
-              format('--previous-version "{0}"', inputs.previous_version) ||
-              ''
-            }}
+            --output-dir "$RUNNER_TEMP/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}"
 
       - name: Summarize release checks
         if: always()
@@ -198,7 +259,7 @@ jobs:
 
       - name: Upload release-check artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openclaw-cross-os-release-checks-${{ matrix.artifact_name }}-${{ github.run_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ live in `openclaw/openclaw`.
   install, upgrade, gateway, and end-to-end validation on GitHub-hosted Linux,
   macOS, and Windows runners, and it is intentionally outside the critical
   release publish path.
+- The cross-OS workflow builds and packs the candidate once, then reuses that
+  same npm tarball across Linux, macOS, and Windows so every lane validates the
+  exact same artifact.
 - Do not start the real private mac publish until public npm preflight, public
   mac validation, private mac validation, and private mac preflight have all
   passed.
@@ -89,6 +92,15 @@ live in `openclaw/openclaw`.
 The cross-OS workflow selects one provider lane per run. It requires the
 matching provider key to exist as a repo secret, but it does not require Apple
 signing or notarization secrets.
+
+Optional repo variables for runner sizing:
+
+- `OPENCLAW_RELEASE_CHECKS_UBUNTU_RUNNER`
+- `OPENCLAW_RELEASE_CHECKS_WINDOWS_RUNNER`
+- `OPENCLAW_RELEASE_CHECKS_MACOS_RUNNER`
+
+Set those to the largest GitHub-hosted runner labels available to this repo if
+you want to override the workflow defaults without editing the workflow file.
 
 ## Repo policy
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ live in `openclaw/openclaw`.
   `.github/workflows/openclaw-macos-validate.yml`
 - Real mac publish workflow:
   `.github/workflows/openclaw-macos-publish.yml`
+- Optional private cross-OS release runtime workflow:
+  `.github/workflows/openclaw-cross-os-release-checks.yml`
 - The validation workflow is the required `swift test` lane for release
   readiness, and each successful run uploads a `macos-validate-<tag>` proof
   artifact. It does not build, sign, notarize, package, or upload release
@@ -54,6 +56,10 @@ live in `openclaw/openclaw`.
 - Validation-only and preflight-only runs may still be dispatched from branches
   while iterating on workflow changes, but their run ids are not valid for real
   publish.
+- The cross-OS release runtime workflow is manual and optional. It is for
+  install, upgrade, gateway, and end-to-end validation on GitHub-hosted Linux,
+  macOS, and Windows runners, and it is intentionally outside the critical
+  release publish path.
 - Do not start the real private mac publish until public npm preflight, public
   mac validation, private mac validation, and private mac preflight have all
   passed.
@@ -73,6 +79,16 @@ live in `openclaw/openclaw`.
 - `SPARKLE_PRIVATE_KEY`
 - `OPENCLAW_PUBLIC_REPO_RELEASE_TOKEN` (`contents:write` on `openclaw/openclaw`
   is sufficient)
+
+## Required repo secrets for cross-OS runtime checks
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `MINIMAX_API_KEY`
+
+The cross-OS workflow selects one provider lane per run. It requires the
+matching provider key to exist as a repo secret, but it does not require Apple
+signing or notarization secrets.
 
 ## Repo policy
 

--- a/scripts/openclaw-cross-os-release-checks.mjs
+++ b/scripts/openclaw-cross-os-release-checks.mjs
@@ -1,0 +1,781 @@
+#!/usr/bin/env node
+
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { createWriteStream, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createServer as createNetServer } from "node:net";
+
+const args = parseArgs(process.argv.slice(2));
+const sourceDir = requireArg(args, "source-dir");
+const provider = requireArg(args, "provider");
+const mode = args["mode"] ?? "both";
+const outputDir = resolve(requireArg(args, "output-dir"));
+const previousVersion = args["previous-version"]?.trim() || "";
+
+const providerConfig = {
+  openai: {
+    secretEnv: "OPENAI_API_KEY",
+    authChoice: "openai-api-key",
+    model: "openai/gpt-5.4",
+  },
+  anthropic: {
+    secretEnv: "ANTHROPIC_API_KEY",
+    authChoice: "apiKey",
+    model: "anthropic/claude-sonnet-4-6",
+  },
+  minimax: {
+    secretEnv: "MINIMAX_API_KEY",
+    authChoice: "minimax-global-api",
+    model: "minimax/MiniMax-M2.7",
+  },
+};
+
+if (!Object.hasOwn(providerConfig, provider)) {
+  throw new Error(`Unsupported provider "${provider}".`);
+}
+
+if (!new Set(["fresh", "upgrade", "both"]).has(mode)) {
+  throw new Error(`Unsupported mode "${mode}".`);
+}
+
+mkdirSync(outputDir, { recursive: true });
+const logsDir = join(outputDir, "logs");
+mkdirSync(logsDir, { recursive: true });
+
+const selectedProvider = providerConfig[provider];
+const providerSecretValue = process.env[selectedProvider.secretEnv]?.trim();
+if (!providerSecretValue) {
+  throw new Error(`Missing ${selectedProvider.secretEnv}.`);
+}
+
+const summary = {
+  platform: process.platform,
+  runnerOs: process.env.OPENCLAW_RELEASE_CHECK_OS ?? "",
+  runnerLabel: process.env.OPENCLAW_RELEASE_CHECK_RUNNER ?? "",
+  provider,
+  mode,
+  previousVersion: previousVersion || null,
+  sourceDir: resolve(sourceDir),
+  sourceSha: "",
+  candidateVersion: "",
+  candidateTgz: "",
+  baselineSpec: previousVersion ? `openclaw@${previousVersion}` : "openclaw@latest",
+  fresh: { status: mode === "upgrade" ? "skipped" : "pending" },
+  upgrade: { status: mode === "fresh" ? "skipped" : "pending" },
+};
+
+let overallFailed = false;
+
+try {
+  const build = await prepareCandidate({
+    sourceDir: resolve(sourceDir),
+    logsDir,
+  });
+  summary.sourceSha = build.sourceSha;
+  summary.candidateVersion = build.candidateVersion;
+  summary.candidateTgz = build.candidateTgz;
+
+  const tgzServer = await startStaticFileServer({
+    filePath: build.candidateTgz,
+    logPath: join(logsDir, "candidate-http-server.log"),
+  });
+
+  try {
+    if (mode === "fresh" || mode === "both") {
+      try {
+        summary.fresh = await runFreshLane({
+          build,
+          logsDir,
+          providerConfig: selectedProvider,
+          providerSecretValue,
+        });
+      } catch (error) {
+        overallFailed = true;
+        summary.fresh = {
+          status: "fail",
+          error: formatError(error),
+        };
+      }
+    }
+
+    if (mode === "upgrade" || mode === "both") {
+      try {
+        summary.upgrade = await runUpgradeLane({
+          build,
+          baselineSpec: summary.baselineSpec,
+          candidateUrl: tgzServer.url,
+          logsDir,
+          providerConfig: selectedProvider,
+          providerSecretValue,
+        });
+      } catch (error) {
+        overallFailed = true;
+        summary.upgrade = {
+          status: "fail",
+          error: formatError(error),
+        };
+      }
+    }
+  } finally {
+    await tgzServer.close();
+  }
+} catch (error) {
+  overallFailed = true;
+  summary.setup = {
+    status: "fail",
+    error: formatError(error),
+  };
+}
+
+writeSummary(outputDir, summary);
+
+if (overallFailed) {
+  process.exit(1);
+}
+
+async function prepareCandidate(params) {
+  const packageJsonPath = join(params.sourceDir, "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const sourceSha = (
+    await runCommand(gitCommand(), ["rev-parse", "HEAD"], {
+      cwd: params.sourceDir,
+      logPath: join(params.logsDir, "git-rev-parse.log"),
+    })
+  ).stdout.trim();
+
+  const buildEnv = {
+    ...process.env,
+    NODE_OPTIONS: "--max-old-space-size=6144",
+  };
+
+  await runCommand(pnpmCommand(), ["install", "--frozen-lockfile"], {
+    cwd: params.sourceDir,
+    env: buildEnv,
+    logPath: join(params.logsDir, "pnpm-install.log"),
+    timeoutMs: 45 * 60 * 1000,
+  });
+
+  await runCommand(pnpmCommand(), ["build"], {
+    cwd: params.sourceDir,
+    env: buildEnv,
+    logPath: join(params.logsDir, "pnpm-build.log"),
+    timeoutMs: 45 * 60 * 1000,
+  });
+
+  const packDir = join(outputDir, "package");
+  mkdirSync(packDir, { recursive: true });
+  const packJsonPath = join(packDir, "pack.json");
+  const packResult = await runCommand(npmCommand(), ["pack", "--ignore-scripts", "--json", "--pack-destination", packDir], {
+    cwd: params.sourceDir,
+    logPath: join(params.logsDir, "npm-pack.log"),
+    timeoutMs: 10 * 60 * 1000,
+  });
+  writeFileSync(packJsonPath, packResult.stdout, "utf8");
+  const parsedPack = JSON.parse(packResult.stdout);
+  const lastPack = Array.isArray(parsedPack) ? parsedPack.at(-1) : null;
+  if (!lastPack?.filename) {
+    throw new Error("npm pack did not report a filename.");
+  }
+
+  return {
+    sourceDir: params.sourceDir,
+    sourceSha,
+    candidateVersion: String(lastPack.version ?? packageJson.version ?? "").trim(),
+    candidateTgz: join(packDir, lastPack.filename),
+  };
+}
+
+async function runFreshLane(params) {
+  const lane = createLaneState("fresh");
+  const cleanup = [];
+  try {
+    const env = buildLaneEnv(lane, params.providerConfig, params.providerSecretValue);
+    await installPackage({
+      spec: params.build.candidateTgz,
+      env,
+      cwd: lane.homeDir,
+      logPath: join(params.logsDir, "fresh-install.log"),
+    });
+    const installed = readInstalledMetadata(lane.prefixDir);
+    verifyInstalledCandidate(installed, params.build);
+
+    await runOnboard({
+      lane,
+      env,
+      providerConfig: params.providerConfig,
+      logPath: join(params.logsDir, "fresh-onboard.log"),
+    });
+
+    const gateway = await startGateway({
+      lane,
+      env,
+      logPath: join(params.logsDir, "fresh-gateway.log"),
+    });
+    cleanup.push(() => stopGateway(gateway));
+
+    await waitForGateway({
+      lane,
+      env,
+      logPath: join(params.logsDir, "fresh-gateway-status.log"),
+    });
+
+    await runModelsSet({
+      lane,
+      env,
+      providerConfig: params.providerConfig,
+      logPath: join(params.logsDir, "fresh-models-set.log"),
+    });
+
+    const agent = await runAgentTurn({
+      lane,
+      env,
+      label: "fresh",
+      logPath: join(params.logsDir, "fresh-agent.log"),
+    });
+
+    return {
+      status: "pass",
+      installedVersion: installed.version,
+      installedCommit: installed.commit,
+      gatewayPort: lane.gatewayPort,
+      agentOutput: trimForSummary(agent.stdout),
+    };
+  } finally {
+    await runCleanup(cleanup);
+  }
+}
+
+async function runUpgradeLane(params) {
+  const lane = createLaneState("upgrade");
+  const cleanup = [];
+  try {
+    const env = buildLaneEnv(lane, params.providerConfig, params.providerSecretValue);
+    await installPackage({
+      spec: params.baselineSpec,
+      env,
+      cwd: lane.homeDir,
+      logPath: join(params.logsDir, "upgrade-install-baseline.log"),
+    });
+
+    const baseline = readInstalledMetadata(lane.prefixDir);
+
+    await runOpenClaw({
+      lane,
+      env,
+      args: ["update", "--tag", params.candidateUrl, "--yes", "--json"],
+      logPath: join(params.logsDir, "upgrade-update.log"),
+      timeoutMs: 20 * 60 * 1000,
+    });
+
+    await runOpenClaw({
+      lane,
+      env,
+      args: ["update", "status", "--json"],
+      logPath: join(params.logsDir, "upgrade-update-status.log"),
+      timeoutMs: 2 * 60 * 1000,
+    });
+
+    const installed = readInstalledMetadata(lane.prefixDir);
+    verifyInstalledCandidate(installed, params.build);
+
+    await runOnboard({
+      lane,
+      env,
+      providerConfig: params.providerConfig,
+      logPath: join(params.logsDir, "upgrade-onboard.log"),
+    });
+
+    const gateway = await startGateway({
+      lane,
+      env,
+      logPath: join(params.logsDir, "upgrade-gateway.log"),
+    });
+    cleanup.push(() => stopGateway(gateway));
+
+    await waitForGateway({
+      lane,
+      env,
+      logPath: join(params.logsDir, "upgrade-gateway-status.log"),
+    });
+
+    await runModelsSet({
+      lane,
+      env,
+      providerConfig: params.providerConfig,
+      logPath: join(params.logsDir, "upgrade-models-set.log"),
+    });
+
+    const agent = await runAgentTurn({
+      lane,
+      env,
+      label: "upgrade",
+      logPath: join(params.logsDir, "upgrade-agent.log"),
+    });
+
+    return {
+      status: "pass",
+      baselineVersion: baseline.version,
+      installedVersion: installed.version,
+      installedCommit: installed.commit,
+      gatewayPort: lane.gatewayPort,
+      agentOutput: trimForSummary(agent.stdout),
+    };
+  } finally {
+    await runCleanup(cleanup);
+  }
+}
+
+function createLaneState(name) {
+  const rootDir = mkdtempSync(join(tmpdir(), `openclaw-${name}-`));
+  const prefixDir = join(rootDir, "prefix");
+  const homeDir = join(rootDir, "home");
+  const stateDir = join(homeDir, ".openclaw");
+  const appDataDir = process.platform === "win32" ? join(homeDir, "AppData", "Roaming") : stateDir;
+  mkdirSync(prefixDir, { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(appDataDir, { recursive: true });
+  return {
+    name,
+    rootDir,
+    prefixDir,
+    homeDir,
+    stateDir,
+    appDataDir,
+    gatewayPort: 0,
+  };
+}
+
+function buildLaneEnv(lane, providerMeta, providerSecretValue) {
+  return {
+    ...process.env,
+    HOME: lane.homeDir,
+    USERPROFILE: lane.homeDir,
+    APPDATA: lane.appDataDir,
+    LOCALAPPDATA: join(lane.homeDir, "AppData", "Local"),
+    OPENCLAW_HOME: lane.homeDir,
+    OPENCLAW_STATE_DIR: lane.stateDir,
+    OPENCLAW_CONFIG_PATH: join(lane.stateDir, "openclaw.json"),
+    NPM_CONFIG_PREFIX: lane.prefixDir,
+    PATH: `${binDirForPrefix(lane.prefixDir)}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+    [providerMeta.secretEnv]: providerSecretValue,
+  };
+}
+
+async function installPackage(params) {
+  await runCommand(npmCommand(), ["install", "-g", params.spec, "--no-fund", "--no-audit"], {
+    cwd: params.cwd,
+    env: params.env,
+    logPath: params.logPath,
+    timeoutMs: 20 * 60 * 1000,
+  });
+}
+
+async function runOnboard(params) {
+  params.lane.gatewayPort = await allocatePort();
+  await runOpenClaw({
+    lane: params.lane,
+    env: params.env,
+    args: [
+      "onboard",
+      "--non-interactive",
+      "--mode",
+      "local",
+      "--auth-choice",
+      params.providerConfig.authChoice,
+      "--secret-input-mode",
+      "ref",
+      "--gateway-port",
+      String(params.lane.gatewayPort),
+      "--gateway-bind",
+      "loopback",
+      "--skip-skills",
+      "--skip-health",
+      "--accept-risk",
+      "--json",
+    ],
+    logPath: params.logPath,
+    timeoutMs: 10 * 60 * 1000,
+  });
+}
+
+async function startGateway(params) {
+  const gatewayLog = createWriteStream(params.logPath, { flags: "a" });
+  const child = spawn(process.execPath, [installedEntryPath(params.lane.prefixDir), "gateway", "run", "--bind", "loopback", "--port", String(params.lane.gatewayPort), "--force"], {
+    cwd: params.lane.homeDir,
+    env: params.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  child.stdout?.pipe(gatewayLog);
+  child.stderr?.pipe(gatewayLog);
+  return { child, logPath: params.logPath };
+}
+
+async function waitForGateway(params) {
+  const statusArgs = await resolveGatewayStatusArgs(params.lane, params.env, params.logPath);
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const result = await runOpenClaw({
+      lane: params.lane,
+      env: params.env,
+      args: statusArgs,
+      logPath: params.logPath,
+      timeoutMs: 15_000,
+      check: false,
+    });
+    if (result.exitCode === 0) {
+      return;
+    }
+    await sleep(2_000);
+  }
+  throw new Error(`Gateway did not become ready on port ${params.lane.gatewayPort}.`);
+}
+
+async function resolveGatewayStatusArgs(lane, env, logPath) {
+  const help = await runOpenClaw({
+    lane,
+    env,
+    args: ["gateway", "status", "--help"],
+    logPath,
+    timeoutMs: 15_000,
+    check: false,
+  });
+  if (help.stdout.includes("--require-rpc") || help.stderr.includes("--require-rpc")) {
+    return ["gateway", "status", "--deep", "--require-rpc", "--timeout", "5000"];
+  }
+  return ["gateway", "status", "--deep"];
+}
+
+async function runModelsSet(params) {
+  await runOpenClaw({
+    lane: params.lane,
+    env: params.env,
+    args: ["models", "set", params.providerConfig.model],
+    logPath: params.logPath,
+    timeoutMs: 2 * 60 * 1000,
+  });
+}
+
+async function runAgentTurn(params) {
+  const sessionId = `cross-os-release-check-${params.label}-${Date.now()}`;
+  const result = await runOpenClaw({
+    lane: params.lane,
+    env: params.env,
+    args: [
+      "agent",
+      "--agent",
+      "main",
+      "--session-id",
+      sessionId,
+      "--message",
+      "Reply with exact ASCII text OK only.",
+      "--json",
+    ],
+    logPath: params.logPath,
+    timeoutMs: 10 * 60 * 1000,
+  });
+  if (!/\bOK\b/u.test(result.stdout)) {
+    throw new Error("Agent output did not contain the expected OK marker.");
+  }
+  return result;
+}
+
+async function stopGateway(gateway) {
+  if (!gateway?.child?.pid) {
+    return;
+  }
+  if (process.platform === "win32") {
+    await runCommand("taskkill", ["/PID", String(gateway.child.pid), "/T", "/F"], {
+      logPath: gateway.logPath,
+      check: false,
+      timeoutMs: 30_000,
+    });
+    return;
+  }
+  gateway.child.kill("SIGTERM");
+  await sleep(2_000);
+  if (!gateway.child.killed) {
+    gateway.child.kill("SIGKILL");
+  }
+}
+
+async function runCleanup(cleanupFns) {
+  for (const cleanupFn of cleanupFns.reverse()) {
+    try {
+      await cleanupFn();
+    } catch {
+      // Ignore cleanup failures so the main failure surface stays visible.
+    }
+  }
+}
+
+async function runOpenClaw(params) {
+  return runCommand(process.execPath, [installedEntryPath(params.lane.prefixDir), ...params.args], {
+    cwd: params.lane.homeDir,
+    env: params.env,
+    logPath: params.logPath,
+    timeoutMs: params.timeoutMs,
+    check: params.check ?? true,
+  });
+}
+
+function readInstalledMetadata(prefixDir) {
+  const packageRoot = installedPackageRoot(prefixDir);
+  const packageJsonPath = join(packageRoot, "package.json");
+  const buildInfoPath = join(packageRoot, "dist", "build-info.json");
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(`Installed package manifest missing: ${packageJsonPath}`);
+  }
+  if (!existsSync(buildInfoPath)) {
+    throw new Error(`Installed build info missing: ${buildInfoPath}`);
+  }
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const buildInfo = JSON.parse(readFileSync(buildInfoPath, "utf8"));
+  return {
+    version: String(packageJson.version ?? "").trim(),
+    commit: String(buildInfo.commit ?? "").trim(),
+  };
+}
+
+function verifyInstalledCandidate(installed, build) {
+  if (installed.version !== build.candidateVersion) {
+    throw new Error(
+      `Installed version mismatch. Expected ${build.candidateVersion}, found ${installed.version || "<missing>"}.`,
+    );
+  }
+  if (installed.commit !== build.sourceSha) {
+    throw new Error(
+      `Installed build commit mismatch. Expected ${build.sourceSha}, found ${installed.commit || "<missing>"}.`,
+    );
+  }
+}
+
+function installedPackageRoot(prefixDir) {
+  return process.platform === "win32"
+    ? join(prefixDir, "node_modules", "openclaw")
+    : join(prefixDir, "lib", "node_modules", "openclaw");
+}
+
+function installedEntryPath(prefixDir) {
+  return join(installedPackageRoot(prefixDir), "openclaw.mjs");
+}
+
+function binDirForPrefix(prefixDir) {
+  return process.platform === "win32" ? prefixDir : join(prefixDir, "bin");
+}
+
+function pnpmCommand() {
+  return process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
+
+function npmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function gitCommand() {
+  return process.platform === "win32" ? "git.exe" : "git";
+}
+
+async function runCommand(command, args, options) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const logStream = createWriteStream(options.logPath, { flags: "a" });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timer =
+      options.timeoutMs && Number.isFinite(options.timeoutMs)
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill(process.platform === "win32" ? undefined : "SIGKILL");
+          }, options.timeoutMs)
+        : null;
+
+    child.stdout?.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      logStream.write(text);
+    });
+    child.stderr?.on("data", (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      logStream.write(text);
+    });
+
+    child.on("error", (error) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      logStream.end();
+      rejectPromise(error);
+    });
+
+    child.on("close", (exitCode) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      logStream.end();
+      const result = {
+        exitCode: exitCode ?? 1,
+        stdout,
+        stderr,
+      };
+      if (timedOut) {
+        rejectPromise(
+          new Error(`Command timed out: ${command} ${args.join(" ")}`),
+        );
+        return;
+      }
+      if ((options.check ?? true) && result.exitCode !== 0) {
+        rejectPromise(
+          new Error(
+            `Command failed (${result.exitCode}): ${command} ${args.join(" ")}\n${trimForSummary(
+              `${stdout}\n${stderr}`,
+            )}`,
+          ),
+        );
+        return;
+      }
+      resolvePromise(result);
+    });
+  });
+}
+
+async function startStaticFileServer(params) {
+  mkdirSync(dirname(params.logPath), { recursive: true });
+  const logStream = createWriteStream(params.logPath, { flags: "a" });
+  const fileName = params.filePath.split(/[/\\]/u).at(-1);
+  const fileBytes = readFileSync(params.filePath);
+  const server = createServer((request, response) => {
+    logStream.write(`${new Date().toISOString()} ${request.method} ${request.url}\n`);
+    if (request.url !== `/${fileName}`) {
+      response.statusCode = 404;
+      response.end("not found");
+      return;
+    }
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/octet-stream");
+    response.setHeader("content-length", String(fileBytes.length));
+    response.end(fileBytes);
+  });
+  const port = await allocatePort();
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(port, "127.0.0.1", resolvePromise);
+  });
+  return {
+    url: `http://127.0.0.1:${port}/${fileName}`,
+    close: () =>
+      new Promise((resolvePromise, rejectPromise) => {
+        server.close((error) => {
+          logStream.end();
+          if (error) {
+            rejectPromise(error);
+            return;
+          }
+          resolvePromise();
+        });
+      }),
+  };
+}
+
+function writeSummary(baseDir, summaryPayload) {
+  const summaryJsonPath = join(baseDir, "summary.json");
+  const summaryMarkdownPath = join(baseDir, "summary.md");
+  writeFileSync(summaryJsonPath, `${JSON.stringify(summaryPayload, null, 2)}\n`, "utf8");
+
+  const lines = [
+    `## ${platformLabel()}`,
+    "",
+    `- Provider: \`${summaryPayload.provider}\``,
+    `- Mode: \`${summaryPayload.mode}\``,
+    `- Source SHA: \`${summaryPayload.sourceSha || "unknown"}\``,
+    `- Candidate version: \`${summaryPayload.candidateVersion || "unknown"}\``,
+    `- Baseline spec: \`${summaryPayload.baselineSpec}\``,
+    summaryPayload.fresh?.status ? `- Fresh lane: \`${summaryPayload.fresh.status}\`` : "",
+    summaryPayload.upgrade?.status ? `- Upgrade lane: \`${summaryPayload.upgrade.status}\`` : "",
+  ].filter(Boolean);
+  writeFileSync(summaryMarkdownPath, `${lines.join("\n")}\n`, "utf8");
+}
+
+function platformLabel() {
+  if (process.platform === "darwin") {
+    return "macOS Release Checks";
+  }
+  if (process.platform === "win32") {
+    return "Windows Release Checks";
+  }
+  return "Linux Release Checks";
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = "true";
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+function requireArg(argsMap, key) {
+  const value = argsMap[key]?.trim();
+  if (!value) {
+    throw new Error(`Missing required --${key} argument.`);
+  }
+  return value;
+}
+
+function trimForSummary(value) {
+  const trimmed = value.trim();
+  if (trimmed.length <= 600) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 600)}...`;
+}
+
+function formatError(error) {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+  return String(error);
+}
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function allocatePort() {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const server = createNetServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close();
+      if (!address || typeof address === "string") {
+        rejectPromise(new Error("Failed to allocate a TCP port."));
+        return;
+      }
+      resolvePromise(address.port);
+    });
+    server.once("error", rejectPromise);
+  });
+}

--- a/scripts/openclaw-cross-os-release-checks.mjs
+++ b/scripts/openclaw-cross-os-release-checks.mjs
@@ -9,11 +9,16 @@ import { dirname, join, resolve } from "node:path";
 import { createServer as createNetServer } from "node:net";
 
 const args = parseArgs(process.argv.slice(2));
-const sourceDir = requireArg(args, "source-dir");
-const provider = requireArg(args, "provider");
-const mode = args["mode"] ?? "both";
 const outputDir = resolve(requireArg(args, "output-dir"));
+const prepareOnly = args["prepare-only"] === "true";
+const sourceDir = args["source-dir"]?.trim() ? resolve(args["source-dir"].trim()) : "";
+const provider = args["provider"]?.trim() || "";
+const mode = args["mode"] ?? "both";
 const previousVersion = args["previous-version"]?.trim() || "";
+const baselineSpec = args["baseline-spec"]?.trim() || (previousVersion ? `openclaw@${previousVersion}` : "openclaw@latest");
+const providedCandidateTgz = args["candidate-tgz"]?.trim() ? resolve(args["candidate-tgz"].trim()) : "";
+const providedCandidateVersion = args["candidate-version"]?.trim() || "";
+const providedSourceSha = args["source-sha"]?.trim() || "";
 
 const providerConfig = {
   openai: {
@@ -33,10 +38,6 @@ const providerConfig = {
   },
 };
 
-if (!Object.hasOwn(providerConfig, provider)) {
-  throw new Error(`Unsupported provider "${provider}".`);
-}
-
 if (!new Set(["fresh", "upgrade", "both"]).has(mode)) {
   throw new Error(`Unsupported mode "${mode}".`);
 }
@@ -44,6 +45,22 @@ if (!new Set(["fresh", "upgrade", "both"]).has(mode)) {
 mkdirSync(outputDir, { recursive: true });
 const logsDir = join(outputDir, "logs");
 mkdirSync(logsDir, { recursive: true });
+
+if (prepareOnly) {
+  if (!sourceDir) {
+    throw new Error("--prepare-only requires --source-dir.");
+  }
+  const build = await prepareCandidate({
+    sourceDir,
+    logsDir,
+  });
+  writeCandidateManifest(outputDir, build);
+  process.exit(0);
+}
+
+if (!Object.hasOwn(providerConfig, provider)) {
+  throw new Error(`Unsupported provider "${provider}".`);
+}
 
 const selectedProvider = providerConfig[provider];
 const providerSecretValue = process.env[selectedProvider.secretEnv]?.trim();
@@ -58,11 +75,11 @@ const summary = {
   provider,
   mode,
   previousVersion: previousVersion || null,
-  sourceDir: resolve(sourceDir),
+  sourceDir,
   sourceSha: "",
   candidateVersion: "",
   candidateTgz: "",
-  baselineSpec: previousVersion ? `openclaw@${previousVersion}` : "openclaw@latest",
+  baselineSpec,
   fresh: { status: mode === "upgrade" ? "skipped" : "pending" },
   upgrade: { status: mode === "fresh" ? "skipped" : "pending" },
 };
@@ -70,10 +87,16 @@ const summary = {
 let overallFailed = false;
 
 try {
-  const build = await prepareCandidate({
-    sourceDir: resolve(sourceDir),
-    logsDir,
-  });
+  const build = sourceDir
+    ? await prepareCandidate({
+        sourceDir,
+        logsDir,
+      })
+    : readProvidedCandidate({
+        candidateTgz: providedCandidateTgz,
+        candidateVersion: providedCandidateVersion,
+        sourceSha: providedSourceSha,
+      });
   summary.sourceSha = build.sourceSha;
   summary.candidateVersion = build.candidateVersion;
   summary.candidateTgz = build.candidateTgz;
@@ -105,7 +128,7 @@ try {
       try {
         summary.upgrade = await runUpgradeLane({
           build,
-          baselineSpec: summary.baselineSpec,
+          baselineSpec,
           candidateUrl: tgzServer.url,
           logsDir,
           providerConfig: selectedProvider,
@@ -185,6 +208,29 @@ async function prepareCandidate(params) {
     sourceSha,
     candidateVersion: String(lastPack.version ?? packageJson.version ?? "").trim(),
     candidateTgz: join(packDir, lastPack.filename),
+    candidateFileName: String(lastPack.filename).trim(),
+  };
+}
+
+function readProvidedCandidate(params) {
+  if (!params.candidateTgz) {
+    throw new Error("Missing required --candidate-tgz argument when --source-dir is not provided.");
+  }
+  if (!existsSync(params.candidateTgz)) {
+    throw new Error(`Candidate package not found: ${params.candidateTgz}`);
+  }
+  if (!params.candidateVersion) {
+    throw new Error("Missing required --candidate-version argument when --source-dir is not provided.");
+  }
+  if (!params.sourceSha) {
+    throw new Error("Missing required --source-sha argument when --source-dir is not provided.");
+  }
+  return {
+    sourceDir: "",
+    sourceSha: params.sourceSha,
+    candidateVersion: params.candidateVersion,
+    candidateTgz: params.candidateTgz,
+    candidateFileName: params.candidateTgz.split(/[/\\]/u).at(-1) ?? "",
   };
 }
 
@@ -222,6 +268,11 @@ async function runFreshLane(params) {
       logPath: join(params.logsDir, "fresh-gateway-status.log"),
     });
 
+    await runDashboardSmoke({
+      lane,
+      logPath: join(params.logsDir, "fresh-dashboard.log"),
+    });
+
     await runModelsSet({
       lane,
       env,
@@ -240,6 +291,7 @@ async function runFreshLane(params) {
       status: "pass",
       installedVersion: installed.version,
       installedCommit: installed.commit,
+      dashboardStatus: "pass",
       gatewayPort: lane.gatewayPort,
       agentOutput: trimForSummary(agent.stdout),
     };
@@ -301,6 +353,11 @@ async function runUpgradeLane(params) {
       logPath: join(params.logsDir, "upgrade-gateway-status.log"),
     });
 
+    await runDashboardSmoke({
+      lane,
+      logPath: join(params.logsDir, "upgrade-dashboard.log"),
+    });
+
     await runModelsSet({
       lane,
       env,
@@ -320,6 +377,7 @@ async function runUpgradeLane(params) {
       baselineVersion: baseline.version,
       installedVersion: installed.version,
       installedCommit: installed.commit,
+      dashboardStatus: "pass",
       gatewayPort: lane.gatewayPort,
       agentOutput: trimForSummary(agent.stdout),
     };
@@ -482,6 +540,42 @@ async function runAgentTurn(params) {
     throw new Error("Agent output did not contain the expected OK marker.");
   }
   return result;
+}
+
+async function runDashboardSmoke(params) {
+  const dashboardUrl = `http://127.0.0.1:${params.lane.gatewayPort}/`;
+  const logStream = createWriteStream(params.logPath, { flags: "a" });
+  const deadline = Date.now() + 30_000;
+  let attempt = 0;
+  try {
+    while (Date.now() < deadline) {
+      attempt += 1;
+      logStream.write(`${new Date().toISOString()} attempt=${attempt} url=${dashboardUrl}\n`);
+      try {
+        const response = await fetch(dashboardUrl, {
+          signal: AbortSignal.timeout(5_000),
+        });
+        const html = await response.text();
+        if (
+          response.ok &&
+          html.includes("<title>OpenClaw Control</title>") &&
+          html.includes("<openclaw-app></openclaw-app>")
+        ) {
+          logStream.write(`${new Date().toISOString()} dashboard-ready status=${response.status}\n`);
+          return;
+        }
+        logStream.write(
+          `${new Date().toISOString()} dashboard-not-ready status=${response.status} title=${html.includes("<title>OpenClaw Control</title>")} app=${html.includes("<openclaw-app></openclaw-app>")}\n`,
+        );
+      } catch (error) {
+        logStream.write(`${new Date().toISOString()} dashboard-fetch-error ${formatError(error)}\n`);
+      }
+      await sleep(1_000);
+    }
+  } finally {
+    logStream.end();
+  }
+  throw new Error(`Dashboard HTML did not become ready at ${dashboardUrl}.`);
 }
 
 async function stopGateway(gateway) {
@@ -703,9 +797,32 @@ function writeSummary(baseDir, summaryPayload) {
     `- Candidate version: \`${summaryPayload.candidateVersion || "unknown"}\``,
     `- Baseline spec: \`${summaryPayload.baselineSpec}\``,
     summaryPayload.fresh?.status ? `- Fresh lane: \`${summaryPayload.fresh.status}\`` : "",
+    summaryPayload.fresh?.dashboardStatus
+      ? `- Fresh dashboard: \`${summaryPayload.fresh.dashboardStatus}\``
+      : "",
     summaryPayload.upgrade?.status ? `- Upgrade lane: \`${summaryPayload.upgrade.status}\`` : "",
+    summaryPayload.upgrade?.dashboardStatus
+      ? `- Upgrade dashboard: \`${summaryPayload.upgrade.dashboardStatus}\``
+      : "",
   ].filter(Boolean);
   writeFileSync(summaryMarkdownPath, `${lines.join("\n")}\n`, "utf8");
+}
+
+function writeCandidateManifest(baseDir, build) {
+  const manifestPath = join(baseDir, "candidate.json");
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        sourceSha: build.sourceSha,
+        candidateVersion: build.candidateVersion,
+        candidateFileName: build.candidateFileName,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
 }
 
 function platformLabel() {

--- a/scripts/openclaw-cross-os-release-checks.mjs
+++ b/scripts/openclaw-cross-os-release-checks.mjs
@@ -2,7 +2,7 @@
 
 import { createServer } from "node:http";
 import { spawn } from "node:child_process";
-import { createWriteStream, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, createWriteStream, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -408,6 +408,7 @@ function createLaneState(name) {
 }
 
 function buildLaneEnv(lane, providerMeta, providerSecretValue) {
+  ensureLocalNpmShim(lane);
   return {
     ...process.env,
     HOME: lane.homeDir,
@@ -430,6 +431,32 @@ async function installPackage(params) {
     logPath: params.logPath,
     timeoutMs: 20 * 60 * 1000,
   });
+}
+
+function ensureLocalNpmShim(lane) {
+  const shimPath = npmShimPath(lane.prefixDir);
+  if (existsSync(shimPath)) {
+    return;
+  }
+  mkdirSync(dirname(shimPath), { recursive: true });
+  const resolvedNpm = resolveCommandPath(npmCommand());
+  if (!resolvedNpm) {
+    throw new Error(`Failed to resolve ${npmCommand()} on PATH.`);
+  }
+  if (process.platform === "win32") {
+    writeFileSync(
+      shimPath,
+      `@echo off\r\nset "NPM_CONFIG_PREFIX=${lane.prefixDir}"\r\n"${resolvedNpm}" %*\r\n`,
+      "utf8",
+    );
+    return;
+  }
+  writeFileSync(
+    shimPath,
+    `#!/bin/sh\nexport NPM_CONFIG_PREFIX='${shellEscapeForSh(lane.prefixDir)}'\nexec '${shellEscapeForSh(resolvedNpm)}' "$@"\n`,
+    "utf8",
+  );
+  chmodSync(shimPath, 0o755);
 }
 
 async function runOnboard(params) {
@@ -658,6 +685,10 @@ function installedEntryPath(prefixDir) {
   return join(installedPackageRoot(prefixDir), "openclaw.mjs");
 }
 
+function npmShimPath(prefixDir) {
+  return process.platform === "win32" ? join(prefixDir, "npm.cmd") : join(prefixDir, "bin", "npm");
+}
+
 function binDirForPrefix(prefixDir) {
   return process.platform === "win32" ? prefixDir : join(prefixDir, "bin");
 }
@@ -860,6 +891,28 @@ function requireArg(argsMap, key) {
     throw new Error(`Missing required --${key} argument.`);
   }
   return value;
+}
+
+function resolveCommandPath(command) {
+  const pathValue = process.env.PATH ?? "";
+  const pathEntries = pathValue.split(process.platform === "win32" ? ";" : ":").filter(Boolean);
+  const candidates =
+    process.platform === "win32" && !command.toLowerCase().endsWith(".cmd")
+      ? [`${command}.cmd`, `${command}.exe`, command]
+      : [command];
+  for (const entry of pathEntries) {
+    for (const candidate of candidates) {
+      const fullPath = join(entry, candidate);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+  return null;
+}
+
+function shellEscapeForSh(value) {
+  return value.replace(/'/gu, `'\"'\"'`);
 }
 
 function trimForSummary(value) {


### PR DESCRIPTION
## Summary

Add an optional private release-check workflow that ports the current Parallels-style install and upgrade checks onto GitHub-hosted Linux, macOS, and Windows runners.

## What changed

- add `.github/workflows/openclaw-cross-os-release-checks.yml`
- add `scripts/openclaw-cross-os-release-checks.mjs` to run fresh-install and real `openclaw update --tag ...` upgrade checks in isolated temp state on each runner
- document the new workflow and its provider-key repo secrets in `README.md`

## Why

This keeps the release-validation intent of the current Parallels checks while removing the Parallels host dependency for the first implementation.

The workflow is manual and optional, so it does not change the existing critical release path.

## Validation

- `node --check scripts/openclaw-cross-os-release-checks.mjs`
- actual GitHub Actions workflow run to follow on this branch