### PR TITLE
[codex] Fix Windows shelling in cross-OS release checks

### DIFF
--- a/scripts/openclaw-cross-os-release-checks.mjs
+++ b/scripts/openclaw-cross-os-release-checks.mjs
@@ -707,9 +707,11 @@ function gitCommand() {
 
 async function runCommand(command, args, options) {
   return new Promise((resolvePromise, rejectPromise) => {
+    const useWindowsShell = process.platform === "win32" && /\.(cmd|bat)$/iu.test(command);
     const child = spawn(command, args, {
       cwd: options.cwd,
       env: options.env,
+      shell: useWindowsShell,
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });


### PR DESCRIPTION
## Summary
- shell Windows .cmd/.bat helper invocations through a shell in the cross-OS release-check helper
- keep the release-check install/update path working on GitHub-hosted Windows runners

## Testing
- node --check scripts/openclaw-cross-os-release-checks.mjs
- live run 24374383955 in openclaw/releases-private exposed the Windows failure this patch addresses
