### PR TITLE
Actions: sync stable npm beta tag in private repo

### DIFF
--- a/.github/workflows/openclaw-npm-dist-tags.yml
+++ b/.github/workflows/openclaw-npm-dist-tags.yml
@@ -2,19 +2,17 @@ name: OpenClaw NPM Dist-Tag Sync
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: Stable OpenClaw release tag whose published version should become the npm beta dist-tag (for example v2026.4.14 or v2026.4.14-1)
-        required: true
-        type: string
+  schedule:
+    - cron: "17 * * * *"
 
 concurrency:
-  group: openclaw-npm-dist-tags-${{ inputs.tag }}
+  group: openclaw-npm-dist-tags
   cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
+  OPENCLAW_REPOSITORY: openclaw/openclaw
 
 jobs:
   sync_beta_to_stable:
@@ -33,47 +31,134 @@ jobs:
             exit 1
           fi
 
-      - name: Validate stable tag input format
-        env:
-          RELEASE_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
-            echo "Invalid stable release tag format: ${RELEASE_TAG}" >&2
-            exit 1
-          fi
-          echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Validate published stable npm version
-        env:
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+      - name: Resolve npm dist-tag state
+        id: resolve_state
         run: |
           set -euo pipefail
-          if ! npm view "openclaw@${RELEASE_VERSION}" version >/dev/null 2>&1; then
-            echo "openclaw@${RELEASE_VERSION} is not published on npm." >&2
-            exit 1
-          fi
-
           latest_version="$(npm view openclaw dist-tags.latest)"
           beta_version="$(npm view openclaw dist-tags.beta)"
 
           echo "Current latest dist-tag: ${latest_version}"
           echo "Current beta dist-tag: ${beta_version}"
 
-          if [[ "${latest_version}" != "${RELEASE_VERSION}" ]]; then
-            echo "npm latest points at ${latest_version}, expected ${RELEASE_VERSION} before syncing beta." >&2
+          if [[ -z "${latest_version}" || -z "${beta_version}" ]]; then
+            echo "Missing npm dist-tag values." >&2
+            exit 1
+          fi
+
+          LATEST_VERSION="${latest_version}" BETA_VERSION="${beta_version}" node <<'NODE' >> "$GITHUB_OUTPUT"
+          const latest = process.env.LATEST_VERSION?.trim() ?? "";
+          const beta = process.env.BETA_VERSION?.trim() ?? "";
+
+          function fail(message) {
+            console.error(message);
+            process.exit(1);
+          }
+
+          function parseRelease(version) {
+            const match = version.match(
+              /^(\d{4})\.(\d+)\.(\d+)(?:-(?:(beta)\.(\d+)|(\d+)))?$/,
+            );
+            if (!match) {
+              return null;
+            }
+            const [, year, month, day, betaMarker, betaNumber, correctionNumber] = match;
+            if (betaMarker) {
+              return {
+                year: Number(year),
+                month: Number(month),
+                day: Number(day),
+                lane: "beta",
+                ordinal: Number(betaNumber),
+              };
+            }
+            if (correctionNumber) {
+              return {
+                year: Number(year),
+                month: Number(month),
+                day: Number(day),
+                lane: "stable",
+                ordinal: Number(correctionNumber),
+              };
+            }
+            return {
+              year: Number(year),
+              month: Number(month),
+              day: Number(day),
+              lane: "stable",
+              ordinal: 0,
+            };
+          }
+
+          function compareRelease(a, b) {
+            for (const key of ["year", "month", "day"]) {
+              if (a[key] !== b[key]) {
+                return a[key] - b[key];
+              }
+            }
+            const laneRank = { beta: 0, stable: 1 };
+            if (laneRank[a.lane] !== laneRank[b.lane]) {
+              return laneRank[a.lane] - laneRank[b.lane];
+            }
+            return a.ordinal - b.ordinal;
+          }
+
+          const latestParsed = parseRelease(latest);
+          const betaParsed = parseRelease(beta);
+
+          if (!latestParsed) {
+            fail(`Could not parse npm latest dist-tag version: ${latest}`);
+          }
+          if (latestParsed.lane !== "stable") {
+            fail(`npm latest must point at a stable release, got ${latest}.`);
+          }
+          if (!betaParsed) {
+            fail(`Could not parse npm beta dist-tag version: ${beta}`);
+          }
+
+          let action = "noop";
+          let reason = "beta_already_matches_latest";
+
+          if (beta !== latest) {
+            const betaVsLatest = compareRelease(betaParsed, latestParsed);
+            if (betaParsed.lane === "beta" && betaVsLatest > 0) {
+              reason = "beta_points_to_newer_prerelease";
+            } else if (betaVsLatest > 0) {
+              reason = "beta_points_to_newer_release";
+            } else {
+              action = "sync";
+              reason = "sync_beta_to_latest_stable";
+            }
+          }
+
+          console.log(`release_version=${latest}`);
+          console.log(`beta_version=${beta}`);
+          console.log(`action=${action}`);
+          console.log(`reason=${reason}`);
+          NODE
+
+      - name: Validate stable release tag exists in public repo
+        if: ${{ steps.resolve_state.outputs.action == 'sync' }}
+        env:
+          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="v${RELEASE_VERSION}"
+          if ! git ls-remote --exit-code "https://github.com/${OPENCLAW_REPOSITORY}.git" "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" >/dev/null; then
+            echo "Public release tag ${RELEASE_TAG} not found in ${OPENCLAW_REPOSITORY}." >&2
             exit 1
           fi
 
       - name: Sync beta dist-tag to stable
+        if: ${{ steps.resolve_state.outputs.action == 'sync' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
         run: |
           set -euo pipefail
           if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
@@ -93,16 +178,37 @@ jobs:
 
           echo "Synced openclaw@${RELEASE_VERSION} to npm beta."
 
+      - name: Skip sync when npm beta should stay as-is
+        if: ${{ steps.resolve_state.outputs.action != 'sync' }}
+        env:
+          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
+          BETA_VERSION: ${{ steps.resolve_state.outputs.beta_version }}
+          REASON: ${{ steps.resolve_state.outputs.reason }}
+        run: |
+          set -euo pipefail
+          echo "No dist-tag change needed."
+          echo "latest=${RELEASE_VERSION}"
+          echo "beta=${BETA_VERSION}"
+          echo "reason=${REASON}"
+
       - name: Summarize dist-tag sync
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
+          BETA_VERSION: ${{ steps.resolve_state.outputs.beta_version }}
+          ACTION: ${{ steps.resolve_state.outputs.action }}
+          REASON: ${{ steps.resolve_state.outputs.reason }}
         run: |
           set -euo pipefail
           {
             echo "## Private npm dist-tag sync output"
             echo
-            echo "- Release tag: \`${RELEASE_TAG}\`"
-            echo "- Version: \`${RELEASE_VERSION}\`"
-            echo "- Result: npm \`beta\` now points at this stable version"
+            echo "- npm \`latest\`: \`${RELEASE_VERSION}\`"
+            echo "- npm \`beta\` before run: \`${BETA_VERSION}\`"
+            echo "- Action: \`${ACTION}\`"
+            echo "- Reason: \`${REASON}\`"
+            if [[ "${ACTION}" == "sync" ]]; then
+              echo "- Result: npm \`beta\` now points at this stable version"
+            else
+              echo "- Result: no change"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-npm-dist-tags.yml
+++ b/.github/workflows/openclaw-npm-dist-tags.yml
@@ -3,7 +3,7 @@ name: OpenClaw NPM Dist-Tag Sync
 on:
   workflow_dispatch:
   schedule:
-    - cron: "17 * * * *"
+    - cron: "17 5 * * *"
 
 concurrency:
   group: openclaw-npm-dist-tags

--- a/.github/workflows/openclaw-npm-dist-tags.yml
+++ b/.github/workflows/openclaw-npm-dist-tags.yml
@@ -1,0 +1,108 @@
+name: OpenClaw NPM Dist-Tag Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Stable OpenClaw release tag whose published version should become the npm beta dist-tag (for example v2026.4.14 or v2026.4.14-1)
+        required: true
+        type: string
+
+concurrency:
+  group: openclaw-npm-dist-tags-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+
+jobs:
+  sync_beta_to_stable:
+    runs-on: ubuntu-latest
+    environment: mac-release
+    permissions:
+      contents: read
+    steps:
+      - name: Require main workflow ref for dist-tag sync
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "Dist-tag sync runs must be dispatched from main."
+            exit 1
+          fi
+
+      - name: Validate stable tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+            echo "Invalid stable release tag format: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Validate published stable npm version
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        run: |
+          set -euo pipefail
+          if ! npm view "openclaw@${RELEASE_VERSION}" version >/dev/null 2>&1; then
+            echo "openclaw@${RELEASE_VERSION} is not published on npm." >&2
+            exit 1
+          fi
+
+          latest_version="$(npm view openclaw dist-tags.latest)"
+          beta_version="$(npm view openclaw dist-tags.beta)"
+
+          echo "Current latest dist-tag: ${latest_version}"
+          echo "Current beta dist-tag: ${beta_version}"
+
+          if [[ "${latest_version}" != "${RELEASE_VERSION}" ]]; then
+            echo "npm latest points at ${latest_version}, expected ${RELEASE_VERSION} before syncing beta." >&2
+            exit 1
+          fi
+
+      - name: Sync beta dist-tag to stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "Missing NPM_TOKEN secret." >&2
+            exit 1
+          fi
+
+          printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${HOME}/.npmrc"
+          npm whoami >/dev/null
+          npm dist-tag add "openclaw@${RELEASE_VERSION}" beta
+
+          synced_beta="$(npm view openclaw dist-tags.beta)"
+          if [[ "${synced_beta}" != "${RELEASE_VERSION}" ]]; then
+            echo "npm beta points at ${synced_beta}, expected ${RELEASE_VERSION} after sync." >&2
+            exit 1
+          fi
+
+          echo "Synced openclaw@${RELEASE_VERSION} to npm beta."
+
+      - name: Summarize dist-tag sync
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Private npm dist-tag sync output"
+            echo
+            echo "- Release tag: \`${RELEASE_TAG}\`"
+            echo "- Version: \`${RELEASE_VERSION}\`"
+            echo "- Result: npm \`beta\` now points at this stable version"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ live in `openclaw/openclaw`.
   `.github/workflows/openclaw-macos-publish.yml`
 - Optional private cross-OS release runtime workflow:
   `.github/workflows/openclaw-cross-os-release-checks.yml`
+- Private npm dist-tag sync workflow:
+  `.github/workflows/openclaw-npm-dist-tags.yml`
 - The validation workflow is the required `swift test` lane for release
   readiness, and each successful run uploads a `macos-validate-<tag>` proof
   artifact. It does not build, sign, notarize, package, or upload release
@@ -45,6 +47,11 @@ live in `openclaw/openclaw`.
   runs.
 - Real publish runs upload the `.zip`, `.dmg`, and `.dSYM.zip` files to the
   existing release in `openclaw/openclaw` automatically.
+- Stable npm dist-tag mutation now lives in the private workflow
+  `.github/workflows/openclaw-npm-dist-tags.yml`, so the public repo can keep
+  trusted publishing for `npm publish` without holding an npm write token.
+- That private workflow only moves `npm beta` to a stable version after
+  confirming `npm latest` already points at the same version.
 - No GitHub App secret is required. Public source checkout and appcast seeding
   happen without extra credentials, and the cross-repo release upload uses
   `OPENCLAW_PUBLIC_REPO_RELEASE_TOKEN`.
@@ -82,6 +89,7 @@ live in `openclaw/openclaw`.
 - `SPARKLE_PRIVATE_KEY`
 - `OPENCLAW_PUBLIC_REPO_RELEASE_TOKEN` (`contents:write` on `openclaw/openclaw`
   is sufficient)
+- `NPM_TOKEN` (used only for `npm dist-tag add`, not for trusted publishing)
 
 ## Required repo secrets for cross-OS runtime checks
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ live in `openclaw/openclaw`.
 - Stable npm dist-tag mutation now lives in the private workflow
   `.github/workflows/openclaw-npm-dist-tags.yml`, so the public repo can keep
   trusted publishing for `npm publish` without holding an npm write token.
-- That private workflow is self-healing: it runs on a schedule and can also be
-  rerun manually without inputs.
+- That private workflow is self-healing: it runs daily and can also be rerun
+  manually without inputs.
 - It only moves `npm beta` to the current stable `npm latest` after confirming
   the matching public release tag exists in `openclaw/openclaw`.
 - It intentionally leaves `beta` alone when it already matches `latest` or when

--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ live in `openclaw/openclaw`.
 - Stable npm dist-tag mutation now lives in the private workflow
   `.github/workflows/openclaw-npm-dist-tags.yml`, so the public repo can keep
   trusted publishing for `npm publish` without holding an npm write token.
-- That private workflow only moves `npm beta` to a stable version after
-  confirming `npm latest` already points at the same version.
+- That private workflow is self-healing: it runs on a schedule and can also be
+  rerun manually without inputs.
+- It only moves `npm beta` to the current stable `npm latest` after confirming
+  the matching public release tag exists in `openclaw/openclaw`.
+- It intentionally leaves `beta` alone when it already matches `latest` or when
+  `beta` points at a newer future prerelease than the current stable release.
 - No GitHub App secret is required. Public source checkout and appcast seeding
   happen without extra credentials, and the cross-repo release upload uses
   `OPENCLAW_PUBLIC_REPO_RELEASE_TOKEN`.


### PR DESCRIPTION
## Summary
- add a private workflow to move npm `beta` to an already-published stable `openclaw` version
- keep npm write auth in `releases-private` instead of the public `openclaw` repo
- document the workflow and required `NPM_TOKEN` secret in the private repo README

## Testing
- parsed `.github/workflows/openclaw-npm-dist-tags.yml` with Ruby `YAML.load_file`
