### PR TITLE
Actions: drop environment from npm dist-tag sync

### DIFF
--- a/.github/workflows/openclaw-npm-dist-tags.yml
+++ b/.github/workflows/openclaw-npm-dist-tags.yml
@@ -17,7 +17,6 @@ env:
 jobs:
   sync_beta_to_stable:
     runs-on: ubuntu-latest
-    environment: mac-release
     permissions:
       contents: read
     steps:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ live in `openclaw/openclaw`.
 - `SPARKLE_PRIVATE_KEY`
 - `OPENCLAW_PUBLIC_REPO_RELEASE_TOKEN` (`contents:write` on `openclaw/openclaw`
   is sufficient)
+
+## Required repo secrets for npm dist-tag sync
+
 - `NPM_TOKEN` (used only for `npm dist-tag add`, not for trusted publishing)
 
 ## Required repo secrets for cross-OS runtime checks
@@ -117,7 +120,10 @@ you want to override the workflow defaults without editing the workflow file.
 ## Repo policy
 
 - Workflow changes are code-owned by `@openclaw/openclaw-release-managers`.
-- The `mac-release` environment exists and should hold all real publish secrets.
+- The `mac-release` environment exists and should hold the real mac publish
+  secrets.
+- `NPM_TOKEN` for `.github/workflows/openclaw-npm-dist-tags.yml` is a repo
+  secret, not a `mac-release` environment secret.
 - Real publish runs must be dispatched from this repo's `main` branch.
 
 ## Pending platform protections


### PR DESCRIPTION
## Summary
- remove the `mac-release` environment from the private npm dist-tag sync workflow
- keep `NPM_TOKEN` as a repository secret in `openclaw/releases-private`
- update the private repo README to document the repo-secret scope for the dist-tag workflow

## Testing
- parsed `.github/workflows/openclaw-npm-dist-tags.yml` with Ruby `YAML.load_file`
