### PR TITLE
feat: persist extended-stable closeout evidence

### DIFF
--- a/.github/workflows/openclaw-release-evidence.yml
+++ b/.github/workflows/openclaw-release-evidence.yml
@@ -3,6 +3,14 @@ name: OpenClaw Release Evidence
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: Evidence operation
+        required: true
+        default: generic
+        type: choice
+        options:
+          - generic
+          - extended-stable-closeout
       release_id:
         description: Release evidence directory name, for example 2026.4.27-beta.1
         required: true
@@ -19,10 +27,46 @@ on:
         type: string
       runs:
         description: "One per line: <label> <owner/repo> <run-id> <blocking|advisory>"
-        required: true
+        required: false
+        default: ""
         type: string
       notes:
         description: Optional release-manager notes to append to the evidence markdown
+        required: false
+        default: ""
+        type: string
+      closeout_run_id:
+        description: Successful openclaw/openclaw extended-stable closeout run id
+        required: false
+        default: ""
+        type: string
+      closeout_run_attempt:
+        description: Exact closeout run attempt; must be 1 because reruns require a fresh run id
+        required: false
+        default: ""
+        type: string
+      closeout_artifact_name:
+        description: Exact extended-stable registry snapshot artifact name
+        required: false
+        default: ""
+        type: string
+      closeout_artifact_digest:
+        description: GitHub-reported SHA-256 digest for the snapshot artifact
+        required: false
+        default: ""
+        type: string
+      plugin_npm_run_id:
+        description: Related successful Plugin NPM Release run id
+        required: false
+        default: ""
+        type: string
+      core_npm_run_id:
+        description: Related core npm release run id
+        required: false
+        default: ""
+        type: string
+      full_release_validation_run_id:
+        description: Related successful Full Release Validation run id
         required: false
         default: ""
         type: string
@@ -37,6 +81,7 @@ env:
 
 jobs:
   write_evidence:
+    if: inputs.mode == 'generic'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -59,6 +104,10 @@ jobs:
           INPUT_NOTES: ${{ inputs.notes }}
         run: |
           set -euo pipefail
+          if [[ -z "${INPUT_RUNS//[[:space:]]/}" ]]; then
+            echo "::error::runs is required in generic evidence mode."
+            exit 1
+          fi
           mkdir -p "$RUNNER_TEMP/openclaw-release-evidence"
           printf '%s\n' "$INPUT_RUNS" > "$RUNNER_TEMP/openclaw-release-evidence/runs.txt"
           printf '%s\n' "$INPUT_NOTES" > "$RUNNER_TEMP/openclaw-release-evidence/notes.md"
@@ -113,4 +162,117 @@ jobs:
             sleep $((attempt * 5))
           done
           echo "::error::Could not push evidence to main after retries."
+          exit 1
+
+  write_extended_stable_closeout:
+    if: inputs.mode == 'extended-stable-closeout'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      RELEASE_ID: ${{ inputs.release_id }}
+      RELEASE_REF: ${{ inputs.release_ref }}
+      PACKAGE_SPEC: ${{ inputs.package_spec }}
+      CLOSEOUT_RUN_ID: ${{ inputs.closeout_run_id }}
+      CLOSEOUT_RUN_ATTEMPT: ${{ inputs.closeout_run_attempt }}
+      CLOSEOUT_ARTIFACT_NAME: ${{ inputs.closeout_artifact_name }}
+      CLOSEOUT_ARTIFACT_DIGEST: ${{ inputs.closeout_artifact_digest }}
+      PLUGIN_NPM_RUN_ID: ${{ inputs.plugin_npm_run_id }}
+      CORE_NPM_RUN_ID: ${{ inputs.core_npm_run_id }}
+      FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
+    steps:
+      - name: Checkout release repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Validate closeout inputs
+        run: |
+          set -euo pipefail
+          for input_name in \
+            RELEASE_ID RELEASE_REF PACKAGE_SPEC CLOSEOUT_RUN_ID CLOSEOUT_RUN_ATTEMPT \
+            CLOSEOUT_ARTIFACT_NAME CLOSEOUT_ARTIFACT_DIGEST PLUGIN_NPM_RUN_ID \
+            CORE_NPM_RUN_ID FULL_RELEASE_VALIDATION_RUN_ID; do
+            if [[ -z "${!input_name//[[:space:]]/}" ]]; then
+              echo "::error::${input_name} is required in extended-stable-closeout mode."
+              exit 1
+            fi
+          done
+          if [[ "$CLOSEOUT_RUN_ATTEMPT" != "1" ]]; then
+            echo "::error::closeout_run_attempt must be 1; dispatch a fresh closeout run instead of rerunning."
+            exit 1
+          fi
+
+      - name: Download exact closeout snapshot
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.closeout_artifact_name }}
+          path: ${{ runner.temp }}/openclaw-extended-stable-closeout
+          github-token: ${{ secrets.OPENCLAW_RELEASES_PUSH_TOKEN }}
+          repository: openclaw/openclaw
+          run-id: ${{ inputs.closeout_run_id }}
+
+      - name: Verify and persist closeout sidecar
+        env:
+          GH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          node scripts/openclaw-extended-stable-closeout-evidence.mjs \
+            --release-id "$RELEASE_ID" \
+            --release-ref "$RELEASE_REF" \
+            --package-spec "$PACKAGE_SPEC" \
+            --closeout-run-id "$CLOSEOUT_RUN_ID" \
+            --closeout-run-attempt "$CLOSEOUT_RUN_ATTEMPT" \
+            --artifact-name "$CLOSEOUT_ARTIFACT_NAME" \
+            --artifact-digest "$CLOSEOUT_ARTIFACT_DIGEST" \
+            --artifact-dir "$RUNNER_TEMP/openclaw-extended-stable-closeout" \
+            --plugin-run-id "$PLUGIN_NPM_RUN_ID" \
+            --core-run-id "$CORE_NPM_RUN_ID" \
+            --full-validation-run-id "$FULL_RELEASE_VALIDATION_RUN_ID"
+
+      - name: Append closeout summary
+        run: |
+          set -euo pipefail
+          evidence_md="evidence/${RELEASE_ID}/release-evidence.md"
+          {
+            cat "$evidence_md"
+            echo
+            echo "Snapshot path: \`evidence/${RELEASE_ID}/extended-stable-registry-snapshot.json\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit closeout sidecar to main
+        env:
+          PUSH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          evidence_path="evidence/${RELEASE_ID}"
+          if [[ -z "${PUSH_TOKEN// }" ]]; then
+            echo "::error::OPENCLAW_RELEASES_PUSH_TOKEN is required to push release evidence directly to main."
+            exit 1
+          fi
+          git config user.name "openclaw-release-bot"
+          git config user.email "release-bot@openclaw.ai"
+          git add "${evidence_path}"
+          if git diff --cached --quiet; then
+            echo "No closeout evidence changes to commit."
+            exit 0
+          fi
+          git commit -m "Evidence: record extended-stable closeout ${RELEASE_ID}"
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            if git rebase origin/main && git push origin HEAD:main; then
+              exit 0
+            fi
+            git rebase --abort || true
+            sleep $((attempt * 5))
+          done
+          echo "::error::Could not push closeout evidence to main after retries."
           exit 1

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ maintenance, and durable release evidence separate from the product source repo.
 - `.github/workflows/openclaw-npm-dist-tags.yml` reconciles npm dist-tags after
   package publication.
 - `.github/workflows/openclaw-release-evidence.yml` records manually supplied
-  release proof runs.
+  release proof runs and can attach a verified extended-stable npm registry
+  snapshot as an immutable sidecar.
 - `.github/workflows/openclaw-release-evidence-from-full-validation.yml` ingests
   child runs from the public `Full Release Validation` workflow.
 
@@ -57,6 +58,7 @@ Each evidence directory contains:
 - `release-evidence.json`
 - `index.json`
 - `runs/<label>.json`
+- `extended-stable-registry-snapshot.json` after an extended-stable npm closeout
 
 Evidence records include release ref provenance, npm package metadata, run URLs,
 workflow names, refs, SHAs, pass/fail state, timing summaries, artifact names,
@@ -117,6 +119,65 @@ gh workflow run openclaw-release-evidence-from-full-validation.yml \
   -f release_ref=v2026.4.24 \
   -f package_spec=openclaw@2026.4.24
 ```
+
+### Extended-Stable npm Closeout
+
+After the read-only closeout workflow in `openclaw/openclaw` succeeds, attach
+its compact registry snapshot to an existing evidence directory:
+
+```bash
+CLOSEOUT_RUN_ID=123456789
+ARTIFACT_NAME=extended-stable-registry-snapshot-v2026.6.33
+
+CLOSEOUT_RUN_ATTEMPT="$(
+  gh api "repos/openclaw/openclaw/actions/runs/${CLOSEOUT_RUN_ID}" --jq .run_attempt
+)"
+CLOSEOUT_ARTIFACT_DIGEST="$(
+  gh api --paginate --slurp \
+    "repos/openclaw/openclaw/actions/runs/${CLOSEOUT_RUN_ID}/artifacts?per_page=100" |
+    jq -er --arg name "$ARTIFACT_NAME" '
+      [.[].artifacts[] | select(.name == $name and .expired == false)] as $matches |
+      if ($matches | length) == 1
+      then $matches[0].digest
+      else error("expected one unexpired artifact named " + $name)
+      end
+    '
+)
+
+gh workflow run openclaw-release-evidence.yml \
+  --repo openclaw/releases \
+  --ref main \
+  -f mode=extended-stable-closeout \
+  -f release_id=2026.6.33 \
+  -f release_ref=v2026.6.33 \
+  -f package_spec=openclaw@2026.6.33 \
+  -f closeout_run_id="$CLOSEOUT_RUN_ID" \
+  -f closeout_run_attempt="$CLOSEOUT_RUN_ATTEMPT" \
+  -f closeout_artifact_name="$ARTIFACT_NAME" \
+  -f closeout_artifact_digest="$CLOSEOUT_ARTIFACT_DIGEST" \
+  -f plugin_npm_run_id=123456780 \
+  -f core_npm_run_id=123456781 \
+  -f full_release_validation_run_id=123456782
+```
+
+The target evidence directory must already contain `release-evidence.json`,
+`release-evidence.md`, and `index.json`. This evidence-only mode has no npm
+publish or selector-mutation authority. It verifies the closeout and related
+runs against the canonical `extended-stable/YYYY.M.33` branch and release SHA,
+then verifies the exact GitHub artifact digest before writing the sidecar. The
+digest above is the GitHub artifact digest, not a digest calculated from the
+extracted JSON file.
+
+The closeout run must be on attempt `1`. GitHub's artifact download action is
+run-id scoped rather than attempt scoped, so a rerun could make a name-based
+download ambiguous. If closeout needs another attempt, dispatch a fresh
+closeout workflow run and use its new run id instead of rerunning the old run.
+
+The `release_id` must equal the exact `YYYY.M.PATCH` snapshot version. The mode
+adds links to the existing `index.json` and `release-evidence.md`; it does not
+regenerate or replace recorded Full Release Validation evidence. Replaying the
+same snapshot is a no-op, while a different snapshot for the same release id
+fails without overwrite.
 
 ## Storage Policy
 

--- a/scripts/openclaw-extended-stable-closeout-evidence.mjs
+++ b/scripts/openclaw-extended-stable-closeout-evidence.mjs
@@ -1,0 +1,615 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PUBLIC_REPO = "openclaw/openclaw";
+const CLOSEOUT_WORKFLOW_NAME = "OpenClaw NPM Extended-Stable Closeout";
+const CLOSEOUT_WORKFLOW_PATH = ".github/workflows/openclaw-npm-extended-stable-closeout.yml";
+const SNAPSHOT_FILE = "extended-stable-registry-snapshot.json";
+const MAX_SNAPSHOT_BYTES = 128 * 1024;
+
+function usage() {
+  console.log(`Usage:
+  node scripts/openclaw-extended-stable-closeout-evidence.mjs \\
+    --release-id 2026.6.33 \\
+    --release-ref v2026.6.33 \\
+    --package-spec openclaw@2026.6.33 \\
+    --closeout-run-id 123 \\
+    --closeout-run-attempt 1 \\
+    --artifact-name extended-stable-registry-snapshot-v2026.6.33 \\
+    --artifact-digest sha256:<64-hex-digits> \\
+    --artifact-dir /tmp/downloaded-artifact \\
+    --plugin-run-id 120 \\
+    --core-run-id 121 \\
+    --full-validation-run-id 122 \\
+    [--output-root evidence]
+`);
+}
+
+function requiredValue(argv, index, flag) {
+  if (index + 1 >= argv.length || argv[index + 1].startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return argv[index + 1];
+}
+
+function parseArgs(argv) {
+  const args = {
+    outputRoot: "evidence",
+    releaseId: "",
+    releaseRef: "",
+    packageSpec: "",
+    closeoutRunId: "",
+    closeoutRunAttempt: "",
+    artifactName: "",
+    artifactDigest: "",
+    artifactDir: "",
+    pluginRunId: "",
+    coreRunId: "",
+    fullValidationRunId: "",
+  };
+  const flags = {
+    "--output-root": "outputRoot",
+    "--release-id": "releaseId",
+    "--release-ref": "releaseRef",
+    "--package-spec": "packageSpec",
+    "--closeout-run-id": "closeoutRunId",
+    "--closeout-run-attempt": "closeoutRunAttempt",
+    "--artifact-name": "artifactName",
+    "--artifact-digest": "artifactDigest",
+    "--artifact-dir": "artifactDir",
+    "--plugin-run-id": "pluginRunId",
+    "--core-run-id": "coreRunId",
+    "--full-validation-run-id": "fullValidationRunId",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === "--help" || flag === "-h") {
+      usage();
+      process.exit(0);
+    }
+    const key = flags[flag];
+    if (!key) {
+      throw new Error(`Unknown argument: ${flag}`);
+    }
+    args[key] = requiredValue(argv, index, flag);
+    index += 1;
+  }
+  for (const [key, value] of Object.entries(args)) {
+    if (key !== "outputRoot" && !value) {
+      throw new Error(`--${key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)} is required`);
+    }
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(args.releaseId)) {
+    throw new Error("--release-id must contain only letters, numbers, dot, underscore, or dash");
+  }
+  for (const key of ["closeoutRunId", "closeoutRunAttempt", "pluginRunId", "coreRunId", "fullValidationRunId"]) {
+    if (!/^[1-9][0-9]*$/.test(args[key])) {
+      throw new Error(`${key} must be a positive integer`);
+    }
+  }
+  return args;
+}
+
+function normalizeDigest(value) {
+  const digest = value.toLowerCase();
+  return digest.startsWith("sha256:") ? digest : `sha256:${digest}`;
+}
+
+function requireSha256Digest(value, label) {
+  const digest = normalizeDigest(value);
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(`${label} must be a SHA-256 digest`);
+  }
+  return digest;
+}
+
+function assertExactKeys(value, keys, label) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} must contain exactly: ${expected.join(", ")}`);
+  }
+}
+
+function parseFinalVersion(value, label) {
+  const match = /^(\d{4})\.([1-9]|1[0-2])\.([1-9]\d*)$/.exec(value);
+  if (!match) {
+    throw new Error(`${label} must be an exact YYYY.M.PATCH version`);
+  }
+  const patch = Number(match[3]);
+  if (!Number.isSafeInteger(patch)) {
+    throw new Error(`${label} patch must be a positive safe integer`);
+  }
+  return { year: Number(match[1]), month: Number(match[2]), patch };
+}
+
+function validateLatest(value) {
+  const match = /^(\d{4})\.([1-9]|1[0-2])\.([1-9]\d*)(?:-([1-9]\d*))?$/.exec(value);
+  if (!match) {
+    throw new Error("snapshot latest must be a stable final or numeric correction release");
+  }
+  const month = Number(match[2]);
+  const patch = Number(match[3]);
+  const correction = match[4] === undefined ? undefined : Number(match[4]);
+  if (
+    !Number.isSafeInteger(patch) ||
+    patch >= 33 ||
+    (correction !== undefined && !Number.isSafeInteger(correction))
+  ) {
+    throw new Error("snapshot latest must have a valid month and base patch below 33");
+  }
+  return { year: Number(match[1]), month, patch };
+}
+
+function validatePackageEntries(entries, expectedNames, version, label) {
+  if (!Array.isArray(entries)) {
+    throw new Error(`snapshot ${label} must be an array`);
+  }
+  const names = entries.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`snapshot ${label}[${index}] must be an object`);
+    }
+    assertExactKeys(entry, ["packageName", "exact", "extendedStable"], `snapshot ${label}[${index}]`);
+    if (
+      typeof entry.packageName !== "string" ||
+      !/^(@[a-z0-9._-]+\/[a-z0-9._-]+|[a-z0-9._-]+)$/.test(entry.packageName)
+    ) {
+      throw new Error(`snapshot ${label}[${index}] has an invalid packageName`);
+    }
+    if (entry.exact !== version || entry.extendedStable !== version) {
+      throw new Error(`snapshot ${label}[${index}] does not resolve to ${version}`);
+    }
+    return entry.packageName;
+  });
+  if (new Set(names).size !== names.length) {
+    throw new Error(`snapshot ${label} contains duplicate package names`);
+  }
+  if (JSON.stringify(names) !== JSON.stringify([...names].sort())) {
+    throw new Error(`snapshot ${label} must be sorted by packageName`);
+  }
+  if (expectedNames && JSON.stringify(names) !== JSON.stringify([...expectedNames].sort())) {
+    throw new Error(`snapshot ${label} must contain exactly ${expectedNames.join(" and ")}`);
+  }
+  return names;
+}
+
+export function validateSnapshotBuffer(buffer, context) {
+  if (buffer.byteLength > MAX_SNAPSHOT_BYTES) {
+    throw new Error(`snapshot exceeds ${MAX_SNAPSHOT_BYTES} bytes`);
+  }
+  let snapshot;
+  try {
+    snapshot = JSON.parse(buffer.toString("utf8"));
+  } catch (error) {
+    throw new Error(`snapshot is not valid JSON: ${error instanceof Error ? error.message : error}`);
+  }
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    throw new Error("snapshot must be a JSON object");
+  }
+  assertExactKeys(snapshot, ["schemaVersion", "version", "corePackages", "latest", "plugins"], "snapshot");
+  if (snapshot.schemaVersion !== 1) {
+    throw new Error("snapshot schemaVersion must be 1");
+  }
+  const extendedStable = parseFinalVersion(snapshot.version, "snapshot version");
+  if (extendedStable.patch < 33) {
+    throw new Error("snapshot version patch must be at least 33");
+  }
+  const expectedRef = `v${snapshot.version}`;
+  if (context.releaseId !== snapshot.version) {
+    throw new Error(`release id must be ${snapshot.version}`);
+  }
+  const normalizedRef = context.releaseRef.replace(/^refs\/tags\//, "");
+  if (normalizedRef !== expectedRef) {
+    throw new Error(`release ref must be ${expectedRef}`);
+  }
+  if (context.packageSpec !== `openclaw@${snapshot.version}`) {
+    throw new Error(`package spec must be openclaw@${snapshot.version}`);
+  }
+  if (context.artifactName !== `extended-stable-registry-snapshot-${expectedRef}`) {
+    throw new Error(`artifact name must be extended-stable-registry-snapshot-${expectedRef}`);
+  }
+  const latest = validateLatest(snapshot.latest);
+  if (
+    latest.year < extendedStable.year ||
+    (latest.year === extendedStable.year && latest.month <= extendedStable.month)
+  ) {
+    throw new Error("snapshot latest must be from a later calendar month than extended-stable");
+  }
+  validatePackageEntries(snapshot.corePackages, ["@openclaw/ai", "openclaw"], snapshot.version, "corePackages");
+  const plugins = validatePackageEntries(snapshot.plugins, null, snapshot.version, "plugins");
+  if (plugins.length === 0) {
+    throw new Error("snapshot plugins must contain at least one package");
+  }
+  return snapshot;
+}
+
+export function validateCloseoutRun(run, context) {
+  if (run.name !== CLOSEOUT_WORKFLOW_NAME) {
+    throw new Error(`closeout run workflow must be ${CLOSEOUT_WORKFLOW_NAME}`);
+  }
+  if (run.path !== CLOSEOUT_WORKFLOW_PATH) {
+    throw new Error(`closeout run path must be ${CLOSEOUT_WORKFLOW_PATH}`);
+  }
+  if (run.event !== "workflow_dispatch" || run.status !== "completed" || run.conclusion !== "success") {
+    throw new Error("closeout run must be a completed successful workflow_dispatch run");
+  }
+  if (Number(run.run_attempt) !== Number(context.closeoutRunAttempt)) {
+    throw new Error("closeout run attempt does not match the requested attempt");
+  }
+  if (Number(run.run_attempt) !== 1) {
+    throw new Error("closeout evidence requires a first-attempt run; dispatch a fresh closeout run instead of rerunning");
+  }
+  if (run.head_sha !== context.releaseSha) {
+    throw new Error("closeout run SHA does not match the release ref");
+  }
+  const expectedBranch = canonicalBranchForReleaseRef(context.releaseRef);
+  if (run.head_branch !== expectedBranch) {
+    throw new Error(`closeout run branch must be ${expectedBranch}`);
+  }
+}
+
+function canonicalBranchForReleaseRef(releaseRef) {
+  const tag = releaseRef.replace(/^refs\/tags\//, "");
+  const version = parseFinalVersion(tag.replace(/^v/, ""), "release ref");
+  return `extended-stable/${version.year}.${version.month}.33`;
+}
+
+export function validateRelatedRun(run, context) {
+  const workflowNames = {
+    plugin: "Plugin NPM Release",
+    core: "OpenClaw NPM Release",
+    validation: "Full Release Validation",
+  };
+  const workflowPaths = {
+    plugin: ".github/workflows/plugin-npm-release.yml",
+    core: ".github/workflows/openclaw-npm-release.yml",
+    validation: ".github/workflows/full-release-validation.yml",
+  };
+  const workflowName = workflowNames[context.kind];
+  if (!workflowName) {
+    throw new Error(`unsupported related run kind: ${context.kind}`);
+  }
+  if (Number(run.id) !== Number(context.runId)) {
+    throw new Error(`related ${context.kind} run id does not match the requested run`);
+  }
+  if (run.name !== workflowName) {
+    throw new Error(`related ${context.kind} run workflow must be ${workflowName}`);
+  }
+  if (run.path !== workflowPaths[context.kind]) {
+    throw new Error(`related ${context.kind} run path must be ${workflowPaths[context.kind]}`);
+  }
+  if (
+    context.kind === "plugin" &&
+    run.display_title !== `Plugin NPM Release [extended-stable] ${context.releaseSha}`
+  ) {
+    throw new Error("related plugin run display title does not match extended-stable and the release SHA");
+  }
+  if (run.event !== "workflow_dispatch" || run.status !== "completed") {
+    throw new Error(`related ${context.kind} run must be a completed workflow_dispatch run`);
+  }
+  const allowedConclusions = context.kind === "core" ? new Set(["success", "failure"]) : new Set(["success"]);
+  if (!allowedConclusions.has(run.conclusion)) {
+    throw new Error(`related ${context.kind} run has disallowed conclusion ${run.conclusion ?? "<missing>"}`);
+  }
+  const expectedBranch = canonicalBranchForReleaseRef(context.releaseRef);
+  if (run.head_branch !== expectedBranch || run.head_sha !== context.releaseSha) {
+    throw new Error(`related ${context.kind} run does not match branch ${expectedBranch} and the release SHA`);
+  }
+}
+
+export function validateFailedCoreRunJobs(jobs) {
+  if (!Array.isArray(jobs) || jobs.length === 0) {
+    throw new Error("failed core run validation requires its complete job list");
+  }
+  const allowedNonFailure = new Set(["success", "skipped"]);
+  const failingJobs = jobs.filter((job) => job.conclusion === "failure");
+  const publishJobs = jobs.filter((job) =>
+    Array.isArray(job.steps) && job.steps.some((step) => step.name === "Publish"),
+  );
+  if (failingJobs.length !== 1 || publishJobs.length !== 1 || failingJobs[0] !== publishJobs[0]) {
+    throw new Error("failed core run must contain exactly one failed publish job");
+  }
+  for (const job of jobs) {
+    if (job !== publishJobs[0] && !allowedNonFailure.has(job.conclusion)) {
+      throw new Error("every non-publish core job must be successful or skipped");
+    }
+  }
+  const steps = jobs.flatMap((job) => (Array.isArray(job.steps) ? job.steps : []));
+  const publishSteps = steps.filter((step) => step.name === "Publish");
+  const readbackSteps = steps.filter(
+    (step) => step.name === "Verify extended-stable registry readback",
+  );
+  if (
+    publishSteps.length !== 1 ||
+    publishSteps[0].conclusion !== "success" ||
+    readbackSteps.length !== 1 ||
+    readbackSteps[0].conclusion !== "failure"
+  ) {
+    throw new Error("failed core run requires publish success and one registry readback failure");
+  }
+  for (const step of steps) {
+    if (step !== readbackSteps[0] && !allowedNonFailure.has(step.conclusion)) {
+      throw new Error("every other core run step must be successful or skipped");
+    }
+  }
+}
+
+export function selectArtifact(artifacts, context) {
+  const matches = artifacts.filter((artifact) => artifact.name === context.artifactName);
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one artifact named ${context.artifactName}`);
+  }
+  const artifact = matches[0];
+  if (artifact.expired) {
+    throw new Error("closeout snapshot artifact has expired");
+  }
+  if (
+    requireSha256Digest(artifact.digest || "", "GitHub artifact digest") !==
+    requireSha256Digest(context.artifactDigest, "requested artifact digest")
+  ) {
+    throw new Error("closeout snapshot artifact digest does not match GitHub metadata");
+  }
+  return artifact;
+}
+
+async function githubJson(pathname) {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  if (!token) {
+    throw new Error("GH_TOKEN is required to verify closeout evidence");
+  }
+  const response = await fetch(`https://api.github.com${pathname}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "openclaw-extended-stable-closeout-evidence",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GitHub API ${pathname} failed: ${response.status} ${response.statusText}\n${body}`);
+  }
+  return body ? JSON.parse(body) : null;
+}
+
+async function resolveReleaseSha(releaseRef) {
+  const tag = releaseRef.replace(/^refs\/tags\//, "");
+  if (!/^v\d{4}\.\d{1,2}\.\d+$/.test(tag)) {
+    throw new Error("release ref must be an exact vYYYY.M.PATCH tag");
+  }
+  const ref = await githubJson(`/repos/${PUBLIC_REPO}/git/ref/tags/${encodeURIComponent(tag)}`);
+  let object = ref?.object;
+  if (object?.type === "tag") {
+    const annotated = await githubJson(`/repos/${PUBLIC_REPO}/git/tags/${object.sha}`);
+    object = annotated?.object;
+  }
+  if (!object?.sha || object.type !== "commit") {
+    throw new Error(`release ref ${tag} does not resolve to a commit`);
+  }
+  return object.sha;
+}
+
+async function listFiles(root) {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const absolute = path.join(root, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error("artifact directory must not contain symbolic links");
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(absolute)));
+    } else if (entry.isFile()) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
+
+async function readSnapshotArtifact(artifactDir) {
+  const files = await listFiles(artifactDir);
+  if (files.length !== 1 || path.basename(files[0]) !== SNAPSHOT_FILE) {
+    throw new Error(`artifact must contain exactly one file named ${SNAPSHOT_FILE}`);
+  }
+  return fs.readFile(files[0]);
+}
+
+function closeoutMetadata(args, run, artifact, snapshot) {
+  const runUrl = `https://github.com/${PUBLIC_REPO}/actions/runs/${args.closeoutRunId}/attempts/${args.closeoutRunAttempt}`;
+  return {
+    version: snapshot.version,
+    closeoutRun: {
+      id: Number(args.closeoutRunId),
+      attempt: Number(args.closeoutRunAttempt),
+      url: run.html_url || runUrl,
+    },
+    artifact: {
+      id: Number(artifact.id),
+      name: artifact.name,
+      digest: requireSha256Digest(args.artifactDigest, "artifact digest"),
+    },
+    relatedRuns: {
+      pluginNpm: Number(args.pluginRunId),
+      coreNpm: Number(args.coreRunId),
+      fullReleaseValidation: Number(args.fullValidationRunId),
+    },
+  };
+}
+
+function renderMarkdownSection(metadata) {
+  const runLink = (id) => `https://github.com/${PUBLIC_REPO}/actions/runs/${id}`;
+  return [
+    "<!-- extended-stable-closeout:start -->",
+    "## Extended-Stable npm Closeout",
+    "",
+    `- Registry snapshot: [\`${SNAPSHOT_FILE}\`](./${SNAPSHOT_FILE})`,
+    `- Closeout run: [${metadata.closeoutRun.id} attempt ${metadata.closeoutRun.attempt}](${metadata.closeoutRun.url})`,
+    `- Plugin npm run: [${metadata.relatedRuns.pluginNpm}](${runLink(metadata.relatedRuns.pluginNpm)})`,
+    `- Core npm run: [${metadata.relatedRuns.coreNpm}](${runLink(metadata.relatedRuns.coreNpm)})`,
+    `- Full Release Validation run: [${metadata.relatedRuns.fullReleaseValidation}](${runLink(metadata.relatedRuns.fullReleaseValidation)})`,
+    `- Snapshot artifact: \`${metadata.artifact.name}\` (\`${metadata.artifact.digest}\`)`,
+    "<!-- extended-stable-closeout:end -->",
+    "",
+  ].join("\n");
+}
+
+function expectedIndexMetadata(metadata, releaseId) {
+  return {
+    ...metadata,
+    snapshotPath: path.posix.join("evidence", releaseId, SNAPSHOT_FILE),
+  };
+}
+
+function valuesEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function inspectMarkdownSection(markdown, expectedSection) {
+  const start = "<!-- extended-stable-closeout:start -->";
+  const end = "<!-- extended-stable-closeout:end -->";
+  const startIndex = markdown.indexOf(start);
+  const endIndex = markdown.indexOf(end);
+  if (startIndex === -1 && endIndex === -1) {
+    return "missing";
+  }
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error("release evidence markdown contains malformed extended-stable closeout metadata");
+  }
+  const afterEnd = endIndex + end.length;
+  if (markdown.indexOf(start, startIndex + start.length) !== -1 || markdown.indexOf(end, afterEnd) !== -1) {
+    throw new Error("release evidence markdown contains duplicate extended-stable closeout metadata");
+  }
+  if (markdown.slice(startIndex, afterEnd).trim() !== expectedSection.trim()) {
+    throw new Error("release evidence markdown contains conflicting extended-stable closeout metadata");
+  }
+  return "present";
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, "utf8"));
+}
+
+export async function persistSidecar({ outputRoot, releaseId, snapshot, metadata }) {
+  const outputDir = path.join(outputRoot, releaseId);
+  const sidecarPath = path.join(outputDir, SNAPSHOT_FILE);
+  const indexPath = path.join(outputDir, "index.json");
+  const markdownPath = path.join(outputDir, "release-evidence.md");
+  const evidencePath = path.join(outputDir, "release-evidence.json");
+  const [index, markdown] = await Promise.all([
+    readJson(indexPath),
+    fs.readFile(markdownPath, "utf8"),
+    fs.access(evidencePath),
+  ]);
+  const canonical = `${JSON.stringify(snapshot, null, 2)}\n`;
+  const nextCloseoutMetadata = expectedIndexMetadata(metadata, releaseId);
+  const markdownSection = renderMarkdownSection(metadata);
+  let sidecarExists = false;
+  try {
+    const existing = await fs.readFile(sidecarPath, "utf8");
+    if (existing !== canonical) {
+      throw new Error(`conflicting immutable sidecar already exists at ${sidecarPath}`);
+    }
+    sidecarExists = true;
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  if (
+    index.extendedStableCloseout &&
+    !valuesEqual(index.extendedStableCloseout, nextCloseoutMetadata)
+  ) {
+    throw new Error("index contains conflicting extended-stable closeout metadata");
+  }
+  const markdownState = inspectMarkdownSection(markdown, markdownSection);
+  if (!sidecarExists && (index.extendedStableCloseout || markdownState === "present")) {
+    throw new Error("closeout metadata exists without its immutable sidecar");
+  }
+  const indexComplete = Boolean(index.extendedStableCloseout);
+  const markdownComplete = markdownState === "present";
+  if (sidecarExists && indexComplete && markdownComplete) {
+    return { status: "unchanged", sidecarPath };
+  }
+  const nextIndex = {
+    ...index,
+    extendedStableCloseout: nextCloseoutMetadata,
+  };
+  const nextMarkdown = markdownComplete ? markdown : `${markdown.trimEnd()}\n\n${markdownSection}`;
+
+  if (!sidecarExists) {
+    await fs.writeFile(sidecarPath, canonical, { flag: "wx" });
+  }
+  if (!indexComplete) {
+    await fs.writeFile(indexPath, `${JSON.stringify(nextIndex, null, 2)}\n`);
+  }
+  if (!markdownComplete) {
+    await fs.writeFile(markdownPath, nextMarkdown);
+  }
+  return { status: sidecarExists ? "recovered" : "written", sidecarPath };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const releaseSha = await resolveReleaseSha(args.releaseRef);
+  const run = await githubJson(`/repos/${PUBLIC_REPO}/actions/runs/${args.closeoutRunId}`);
+  validateCloseoutRun(run, { ...args, releaseSha });
+  const artifactPayload = await githubJson(
+    `/repos/${PUBLIC_REPO}/actions/runs/${args.closeoutRunId}/artifacts?per_page=100`,
+  );
+  const artifact = selectArtifact(artifactPayload?.artifacts || [], args);
+  const relatedRunRequests = [
+    ["plugin", args.pluginRunId],
+    ["core", args.coreRunId],
+    ["validation", args.fullValidationRunId],
+  ];
+  const relatedRuns = await Promise.all(
+    relatedRunRequests.map(([, runId]) =>
+      githubJson(`/repos/${PUBLIC_REPO}/actions/runs/${runId}`),
+    ),
+  );
+  for (let index = 0; index < relatedRunRequests.length; index += 1) {
+    const [kind, runId] = relatedRunRequests[index];
+    validateRelatedRun(relatedRuns[index], {
+      kind,
+      runId,
+      releaseRef: args.releaseRef,
+      releaseSha,
+    });
+  }
+  const coreRun = relatedRuns[1];
+  if (coreRun.conclusion === "failure") {
+    const jobsPayload = await githubJson(
+      `/repos/${PUBLIC_REPO}/actions/runs/${args.coreRunId}/jobs?filter=latest&per_page=100`,
+    );
+    if (jobsPayload?.total_count !== jobsPayload?.jobs?.length) {
+      throw new Error("failed core run job list is incomplete");
+    }
+    validateFailedCoreRunJobs(jobsPayload?.jobs || []);
+  }
+  const snapshotBuffer = await readSnapshotArtifact(args.artifactDir);
+  const snapshot = validateSnapshotBuffer(snapshotBuffer, args);
+  const metadata = closeoutMetadata(args, run, artifact, snapshot);
+  const result = await persistSidecar({
+    outputRoot: args.outputRoot,
+    releaseId: args.releaseId,
+    snapshot,
+    metadata,
+  });
+  const verb =
+    result.status === "written"
+      ? "Wrote"
+      : result.status === "recovered"
+        ? "Recovered"
+        : "Verified unchanged";
+  console.log(`${verb} ${result.sidecarPath}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/openclaw-extended-stable-closeout-evidence.test.mjs
+++ b/scripts/openclaw-extended-stable-closeout-evidence.test.mjs
@@ -1,0 +1,516 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  persistSidecar,
+  selectArtifact,
+  validateCloseoutRun,
+  validateFailedCoreRunJobs,
+  validateRelatedRun,
+  validateSnapshotBuffer,
+} from "./openclaw-extended-stable-closeout-evidence.mjs";
+
+function validSnapshot() {
+  return {
+    schemaVersion: 1,
+    version: "2026.6.33",
+    corePackages: [
+      { packageName: "@openclaw/ai", exact: "2026.6.33", extendedStable: "2026.6.33" },
+      { packageName: "openclaw", exact: "2026.6.33", extendedStable: "2026.6.33" },
+    ],
+    latest: "2026.7.4-1",
+    plugins: [
+      { packageName: "@openclaw/discord", exact: "2026.6.33", extendedStable: "2026.6.33" },
+      { packageName: "@openclaw/slack", exact: "2026.6.33", extendedStable: "2026.6.33" },
+    ],
+  };
+}
+
+const snapshotContext = {
+  releaseId: "2026.6.33",
+  releaseRef: "v2026.6.33",
+  packageSpec: "openclaw@2026.6.33",
+  artifactName: "extended-stable-registry-snapshot-v2026.6.33",
+};
+
+function snapshotBuffer(value = validSnapshot()) {
+  return Buffer.from(JSON.stringify(value));
+}
+
+test("accepts the compact sorted registry snapshot", () => {
+  assert.deepEqual(validateSnapshotBuffer(snapshotBuffer(), snapshotContext), validSnapshot());
+});
+
+test("rejects snapshot identity mismatches", () => {
+  assert.throws(
+    () => validateSnapshotBuffer(snapshotBuffer(), { ...snapshotContext, releaseId: "release-2026.6.33" }),
+    /release id must be/,
+  );
+  assert.throws(
+    () => validateSnapshotBuffer(snapshotBuffer(), { ...snapshotContext, releaseRef: "v2026.6.34" }),
+    /release ref must be/,
+  );
+  assert.throws(
+    () => validateSnapshotBuffer(snapshotBuffer(), { ...snapshotContext, packageSpec: "openclaw@2026.6.34" }),
+    /package spec must be/,
+  );
+  assert.throws(
+    () => validateSnapshotBuffer(snapshotBuffer(), { ...snapshotContext, artifactName: "wrong" }),
+    /artifact name must be/,
+  );
+});
+
+test("rejects malformed, oversized, and semantically incomplete snapshots", () => {
+  assert.throws(() => validateSnapshotBuffer(Buffer.from("{"), snapshotContext), /not valid JSON/);
+  assert.throws(
+    () => validateSnapshotBuffer(Buffer.alloc(128 * 1024 + 1, 32), snapshotContext),
+    /exceeds 131072 bytes/,
+  );
+  const extra = { ...validSnapshot(), unexpected: true };
+  assert.throws(() => validateSnapshotBuffer(snapshotBuffer(extra), snapshotContext), /must contain exactly/);
+  const unsorted = validSnapshot();
+  unsorted.plugins.reverse();
+  assert.throws(() => validateSnapshotBuffer(snapshotBuffer(unsorted), snapshotContext), /must be sorted/);
+  const emptyPlugins = { ...validSnapshot(), plugins: [] };
+  assert.throws(() => validateSnapshotBuffer(snapshotBuffer(emptyPlugins), snapshotContext), /at least one/);
+});
+
+test("rejects extended-stable and latest versions outside the monthly contract", () => {
+  const early = { ...validSnapshot(), version: "2026.6.32" };
+  early.corePackages = early.corePackages.map((entry) => ({
+    ...entry,
+    exact: "2026.6.32",
+    extendedStable: "2026.6.32",
+  }));
+  early.plugins = early.plugins.map((entry) => ({
+    ...entry,
+    exact: "2026.6.32",
+    extendedStable: "2026.6.32",
+  }));
+  assert.throws(
+    () =>
+      validateSnapshotBuffer(snapshotBuffer(early), {
+        releaseId: "2026.6.32",
+        releaseRef: "v2026.6.32",
+        packageSpec: "openclaw@2026.6.32",
+        artifactName: "extended-stable-registry-snapshot-v2026.6.32",
+      }),
+    /patch must be at least 33/,
+  );
+  const sameMonth = { ...validSnapshot(), latest: "2026.6.4" };
+  assert.throws(
+    () => validateSnapshotBuffer(snapshotBuffer(sameMonth), snapshotContext),
+    /later calendar month/,
+  );
+  const latePatch = { ...validSnapshot(), latest: "2026.7.33" };
+  assert.throws(
+    () => validateSnapshotBuffer(snapshotBuffer(latePatch), snapshotContext),
+    /base patch below 33/,
+  );
+  for (const version of ["2026.06.33", "2026.6.0", `2026.6.${Number.MAX_SAFE_INTEGER}0`]) {
+    const invalid = { ...validSnapshot(), version };
+    assert.throws(
+      () =>
+        validateSnapshotBuffer(snapshotBuffer(invalid), {
+          releaseId: version,
+          releaseRef: `v${version}`,
+          packageSpec: `openclaw@${version}`,
+          artifactName: `extended-stable-registry-snapshot-v${version}`,
+        }),
+      /exact YYYY\.M\.PATCH|positive safe integer/,
+    );
+  }
+  for (const latest of ["2026.07.2", "2026.7.0", "2026.7.2-0", `2026.7.${Number.MAX_SAFE_INTEGER}0`]) {
+    assert.throws(
+      () => validateSnapshotBuffer(snapshotBuffer({ ...validSnapshot(), latest }), snapshotContext),
+      /stable final|positive safe integer|base patch below 33/,
+    );
+  }
+});
+
+test("validates exact closeout workflow identity", () => {
+  const run = {
+    name: "OpenClaw NPM Extended-Stable Closeout",
+    path: ".github/workflows/openclaw-npm-extended-stable-closeout.yml",
+    event: "workflow_dispatch",
+    status: "completed",
+    conclusion: "success",
+    run_attempt: 1,
+    head_sha: "a".repeat(40),
+    head_branch: "extended-stable/2026.6.33",
+  };
+  const context = {
+    releaseRef: "v2026.6.33",
+    releaseSha: "a".repeat(40),
+    closeoutRunAttempt: "1",
+  };
+  assert.doesNotThrow(() => validateCloseoutRun(run, context));
+  assert.throws(
+    () => validateCloseoutRun({ ...run, path: `${run.path}@refs/heads/main` }, context),
+    /run path must be/,
+  );
+  assert.throws(
+    () =>
+      validateCloseoutRun(
+        { ...run, run_attempt: 2 },
+        { ...context, closeoutRunAttempt: "2" },
+      ),
+    /requires a first-attempt run/,
+  );
+  assert.throws(() => validateCloseoutRun({ ...run, event: "push" }, context), /workflow_dispatch/);
+  assert.throws(
+    () => validateCloseoutRun({ ...run, head_sha: "b".repeat(40) }, context),
+    /SHA does not match/,
+  );
+  assert.throws(
+    () => validateCloseoutRun({ ...run, head_branch: "main" }, context),
+    /branch must be extended-stable\/2026\.6\.33/,
+  );
+});
+
+test("binds related release runs to the exact workflow, branch, and SHA", () => {
+  const context = {
+    runId: "101",
+    releaseRef: "v2026.6.33",
+    releaseSha: "a".repeat(40),
+  };
+  const baseRun = {
+    id: 101,
+    event: "workflow_dispatch",
+    status: "completed",
+    conclusion: "success",
+    head_branch: "extended-stable/2026.6.33",
+    head_sha: "a".repeat(40),
+  };
+  const pluginRun = {
+    ...baseRun,
+    name: "Plugin NPM Release",
+    path: ".github/workflows/plugin-npm-release.yml",
+    display_title: `Plugin NPM Release [extended-stable] ${context.releaseSha}`,
+  };
+  const validationRun = {
+    ...baseRun,
+    name: "Full Release Validation",
+    path: ".github/workflows/full-release-validation.yml",
+  };
+  const coreRun = {
+    ...baseRun,
+    name: "OpenClaw NPM Release",
+    path: ".github/workflows/openclaw-npm-release.yml",
+  };
+  assert.doesNotThrow(() =>
+    validateRelatedRun(pluginRun, { ...context, kind: "plugin" }),
+  );
+  assert.doesNotThrow(() =>
+    validateRelatedRun(validationRun, { ...context, kind: "validation" }),
+  );
+  assert.doesNotThrow(() =>
+    validateRelatedRun({ ...coreRun, conclusion: "failure" }, { ...context, kind: "core" }),
+  );
+  assert.throws(
+    () => validateRelatedRun({ ...pluginRun, conclusion: "failure" }, { ...context, kind: "plugin" }),
+    /disallowed conclusion/,
+  );
+  assert.throws(
+    () => validateRelatedRun({ ...coreRun, head_branch: "main" }, { ...context, kind: "core" }),
+    /does not match branch/,
+  );
+  assert.throws(
+    () => validateRelatedRun({ ...coreRun, id: 102 }, { ...context, kind: "core" }),
+    /run id does not match/,
+  );
+  assert.throws(
+    () =>
+      validateRelatedRun(
+        { ...validationRun, head_sha: "b".repeat(40) },
+        { ...context, kind: "validation" },
+      ),
+    /does not match branch/,
+  );
+  assert.throws(
+    () => validateRelatedRun({ ...coreRun, path: pluginRun.path }, { ...context, kind: "core" }),
+    /run path must be/,
+  );
+  assert.throws(
+    () =>
+      validateRelatedRun(
+        { ...pluginRun, display_title: "Plugin NPM Release" },
+        { ...context, kind: "plugin" },
+      ),
+    /display title does not match/,
+  );
+});
+
+test("accepts only the bounded failed core publication shape", () => {
+  const bounded = [
+    {
+      name: "preflight_openclaw_npm",
+      conclusion: "skipped",
+      steps: [],
+    },
+    {
+      name: "publish_openclaw_npm",
+      conclusion: "failure",
+      steps: [
+        { name: "Checkout", conclusion: "success" },
+        { name: "Publish", conclusion: "success" },
+        { name: "Verify extended-stable registry readback", conclusion: "failure" },
+        { name: "Summarize extended-stable npm publication", conclusion: "success" },
+        { name: "Post Setup", conclusion: "skipped" },
+      ],
+    },
+  ];
+  assert.doesNotThrow(() => validateFailedCoreRunJobs(bounded));
+  assert.throws(
+    () =>
+      validateFailedCoreRunJobs([
+        ...bounded,
+        { name: "unexpected", conclusion: "timed_out", steps: [] },
+      ]),
+    /exactly one failed publish job|successful or skipped/,
+  );
+  assert.throws(
+    () =>
+      validateFailedCoreRunJobs([
+        {
+          ...bounded[1],
+          steps: [
+            { name: "Publish", conclusion: "success" },
+            { name: "Verify extended-stable registry readback", conclusion: "failure" },
+            { name: "Unrelated", conclusion: "cancelled" },
+          ],
+        },
+      ]),
+    /every other core run step/,
+  );
+  assert.throws(
+    () =>
+      validateFailedCoreRunJobs([
+        {
+          ...bounded[1],
+          steps: [
+            { name: "Publish", conclusion: "failure" },
+            { name: "Verify extended-stable registry readback", conclusion: "failure" },
+          ],
+        },
+      ]),
+    /publish success/,
+  );
+});
+
+test("requires one unexpired artifact with the exact GitHub digest", () => {
+  const context = {
+    artifactName: snapshotContext.artifactName,
+    artifactDigest: `sha256:${"a".repeat(64)}`,
+  };
+  const artifact = {
+    id: 42,
+    name: snapshotContext.artifactName,
+    digest: `sha256:${"a".repeat(64)}`,
+    expired: false,
+  };
+  assert.equal(selectArtifact([artifact], context), artifact);
+  assert.throws(
+    () => selectArtifact([{ ...artifact, digest: `sha256:${"b".repeat(64)}` }], context),
+    /digest does not match/,
+  );
+  assert.throws(() => selectArtifact([{ ...artifact, expired: true }], context), /expired/);
+});
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-closeout-evidence-"));
+  const releaseId = "release-2026.6.33";
+  const dir = path.join(root, releaseId);
+  await fs.mkdir(path.join(dir, "runs"), { recursive: true });
+  const evidence = { schemaVersion: 1, runs: [{ id: 1 }] };
+  const index = { releaseId, markdownPath: `evidence/${releaseId}/release-evidence.md` };
+  const markdown = "# Existing release evidence\n\nExisting Full Validation proof.\n";
+  const runFile = '{"preserve":true}\n';
+  await Promise.all([
+    fs.writeFile(path.join(dir, "release-evidence.json"), `${JSON.stringify(evidence)}\n`),
+    fs.writeFile(path.join(dir, "index.json"), `${JSON.stringify(index)}\n`),
+    fs.writeFile(path.join(dir, "release-evidence.md"), markdown),
+    fs.writeFile(path.join(dir, "runs", "full-release-validation.json"), runFile),
+  ]);
+  return { root, releaseId, dir, evidence, runFile };
+}
+
+function metadata(overrides = {}) {
+  return {
+    version: "2026.6.33",
+    closeoutRun: { id: 100, attempt: 1, url: "https://github.com/openclaw/openclaw/actions/runs/100" },
+    artifact: {
+      id: 200,
+      name: snapshotContext.artifactName,
+      digest: `sha256:${"a".repeat(64)}`,
+    },
+    relatedRuns: { pluginNpm: 97, coreNpm: 98, fullReleaseValidation: 99 },
+    ...overrides,
+  };
+}
+
+test("writes an immutable sidecar and preserves existing Full Validation evidence", async () => {
+  const state = await fixture();
+  const result = await persistSidecar({
+    outputRoot: state.root,
+    releaseId: state.releaseId,
+    snapshot: validSnapshot(),
+    metadata: metadata(),
+  });
+  assert.equal(result.status, "written");
+  assert.deepEqual(
+    JSON.parse(await fs.readFile(path.join(state.dir, "extended-stable-registry-snapshot.json"), "utf8")),
+    validSnapshot(),
+  );
+  assert.deepEqual(
+    JSON.parse(await fs.readFile(path.join(state.dir, "release-evidence.json"), "utf8")),
+    state.evidence,
+  );
+  assert.equal(
+    await fs.readFile(path.join(state.dir, "runs", "full-release-validation.json"), "utf8"),
+    state.runFile,
+  );
+  const index = JSON.parse(await fs.readFile(path.join(state.dir, "index.json"), "utf8"));
+  assert.equal(
+    index.extendedStableCloseout.snapshotPath,
+    `evidence/${state.releaseId}/extended-stable-registry-snapshot.json`,
+  );
+  const markdown = await fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8");
+  assert.match(markdown, /Existing Full Validation proof/);
+  assert.match(markdown, /Extended-Stable npm Closeout/);
+});
+
+test("identical replay is a no-op", async () => {
+  const state = await fixture();
+  const input = {
+    outputRoot: state.root,
+    releaseId: state.releaseId,
+    snapshot: validSnapshot(),
+    metadata: metadata(),
+  };
+  await persistSidecar(input);
+  const indexBefore = await fs.readFile(path.join(state.dir, "index.json"), "utf8");
+  const markdownBefore = await fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8");
+  const result = await persistSidecar(input);
+  assert.equal(result.status, "unchanged");
+  assert.equal(await fs.readFile(path.join(state.dir, "index.json"), "utf8"), indexBefore);
+  assert.equal(await fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8"), markdownBefore);
+});
+
+test("identical replay completes metadata after a sidecar-first partial write", async () => {
+  const state = await fixture();
+  await fs.writeFile(
+    path.join(state.dir, "extended-stable-registry-snapshot.json"),
+    `${JSON.stringify(validSnapshot(), null, 2)}\n`,
+    { flag: "wx" },
+  );
+  const result = await persistSidecar({
+    outputRoot: state.root,
+    releaseId: state.releaseId,
+    snapshot: validSnapshot(),
+    metadata: metadata(),
+  });
+  assert.equal(result.status, "recovered");
+  const index = JSON.parse(await fs.readFile(path.join(state.dir, "index.json"), "utf8"));
+  assert.equal(index.extendedStableCloseout.closeoutRun.id, 100);
+  assert.match(
+    await fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8"),
+    /Extended-Stable npm Closeout/,
+  );
+  assert.deepEqual(
+    JSON.parse(await fs.readFile(path.join(state.dir, "release-evidence.json"), "utf8")),
+    state.evidence,
+  );
+  assert.equal(
+    await fs.readFile(path.join(state.dir, "runs", "full-release-validation.json"), "utf8"),
+    state.runFile,
+  );
+});
+
+test("identical replay rejects conflicting index metadata without changing evidence", async () => {
+  const state = await fixture();
+  const input = {
+    outputRoot: state.root,
+    releaseId: state.releaseId,
+    snapshot: validSnapshot(),
+    metadata: metadata(),
+  };
+  await persistSidecar(input);
+  const indexPath = path.join(state.dir, "index.json");
+  const index = JSON.parse(await fs.readFile(indexPath, "utf8"));
+  index.extendedStableCloseout.closeoutRun.id = 999;
+  await fs.writeFile(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+  const before = await Promise.all([
+    fs.readFile(indexPath, "utf8"),
+    fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8"),
+    fs.readFile(path.join(state.dir, "release-evidence.json"), "utf8"),
+  ]);
+  await assert.rejects(persistSidecar(input), /index contains conflicting/);
+  assert.deepEqual(
+    await Promise.all([
+      fs.readFile(indexPath, "utf8"),
+      fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8"),
+      fs.readFile(path.join(state.dir, "release-evidence.json"), "utf8"),
+    ]),
+    before,
+  );
+});
+
+test("conflicting replay fails without changing existing evidence", async () => {
+  const state = await fixture();
+  await persistSidecar({
+    outputRoot: state.root,
+    releaseId: state.releaseId,
+    snapshot: validSnapshot(),
+    metadata: metadata(),
+  });
+  const before = await Promise.all([
+    fs.readFile(path.join(state.dir, "release-evidence.json"), "utf8"),
+    fs.readFile(path.join(state.dir, "index.json"), "utf8"),
+    fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8"),
+  ]);
+  const conflicting = { ...validSnapshot(), latest: "2026.7.5" };
+  await assert.rejects(
+    persistSidecar({
+      outputRoot: state.root,
+      releaseId: state.releaseId,
+      snapshot: conflicting,
+      metadata: metadata(),
+    }),
+    /conflicting immutable sidecar/,
+  );
+  assert.deepEqual(
+    await Promise.all([
+      fs.readFile(path.join(state.dir, "release-evidence.json"), "utf8"),
+      fs.readFile(path.join(state.dir, "index.json"), "utf8"),
+      fs.readFile(path.join(state.dir, "release-evidence.md"), "utf8"),
+    ]),
+    before,
+  );
+});
+
+test("workflow preserves generic evidence as the default and keeps closeout non-mutating", async () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const workflow = await fs.readFile(
+    path.join(root, ".github", "workflows", "openclaw-release-evidence.yml"),
+    "utf8",
+  );
+  const closeoutScript = await fs.readFile(
+    path.join(root, "scripts", "openclaw-extended-stable-closeout-evidence.mjs"),
+    "utf8",
+  );
+  assert.match(workflow, /default: generic/);
+  assert.match(workflow, /write_evidence:\n\s+if: inputs\.mode == 'generic'/);
+  assert.match(workflow, /node scripts\/openclaw-release-evidence\.mjs/);
+  assert.match(workflow, /write_extended_stable_closeout:\n\s+if: inputs\.mode == 'extended-stable-closeout'/);
+  assert.match(
+    workflow,
+    /write_extended_stable_closeout:[\s\S]*?permissions:\n\s+actions: read\n\s+contents: read/,
+  );
+  assert.match(workflow, /closeout_run_attempt must be 1/);
+  assert.doesNotMatch(`${workflow}\n${closeoutScript}`, /npm\s+(?:publish|dist-tag)/);
+});


### PR DESCRIPTION
## Summary

- add a closed `extended-stable-closeout` mode to the existing release-evidence workflow
- validate the exact public closeout, plugin publication, core publication, and full-validation runs before accepting evidence
- persist an immutable evidence record with exact-replay no-op behavior, partial-write recovery, and conflict rejection
- keep the default evidence workflow unchanged and grant no npm mutation authority

Companion source PR: https://github.com/openclaw/openclaw/pull/100508

## Validation

- `node --test test/openclaw-extended-stable-closeout-evidence.test.mjs` (14/14 passed)
- workflow YAML parse, Node syntax checks, and `git diff --check` passed
- isolated Verdaccio proof covered a new line, patch update, stale-selector rejection, repair, and unchanged `latest`

## Scope

This repository only validates and stores authoritative closeout evidence. Publication and registry readback remain owned by the source-repository workflow.
