### PR TITLE
fix(ci): persist release evidence run attempts

### DIFF
--- a/.github/workflows/openclaw-release-evidence-from-full-validation.yml
+++ b/.github/workflows/openclaw-release-evidence-from-full-validation.yml
@@ -7,6 +7,11 @@ on:
         description: Public openclaw/openclaw Full Release Validation run id
         required: true
         type: string
+      full_validation_run_attempt:
+        description: Optional exact Full Release Validation attempt; blank uses the current attempt
+        required: false
+        default: ""
+        type: string
       release_id:
         description: Release evidence directory name, for example 2026.4.27-beta.1
         required: true
@@ -36,6 +41,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   FULL_VALIDATION_RUN_ID: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.full_validation_run_id || inputs.full_validation_run_id }}
+  FULL_VALIDATION_RUN_ATTEMPT: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.full_validation_run_attempt || inputs.full_validation_run_attempt }}
   RELEASE_ID: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.release_id || inputs.release_id }}
   RELEASE_REF: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.release_ref || inputs.release_ref }}
   PACKAGE_SPEC: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.package_spec || inputs.package_spec }}
@@ -73,8 +79,17 @@ jobs:
           GH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_PRIVATE_PUSH_TOKEN }}
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "repository_dispatch" && ! "$FULL_VALIDATION_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::repository_dispatch requires a positive full_validation_run_attempt."
+            exit 1
+          fi
+          attempt_args=()
+          if [[ -n "$FULL_VALIDATION_RUN_ATTEMPT" ]]; then
+            attempt_args=(--full-validation-run-attempt "$FULL_VALIDATION_RUN_ATTEMPT")
+          fi
           node scripts/openclaw-release-evidence-from-full-validation.mjs \
             --full-validation-run-id "$FULL_VALIDATION_RUN_ID" \
+            "${attempt_args[@]}" \
             --release-id "$RELEASE_ID" \
             --release-ref "$RELEASE_REF" \
             --package-spec "$PACKAGE_SPEC" \

--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ fail the release by itself.
 `full-release-validation-<run-id>-<attempt>` manifest artifact. The ingest
 rejects missing, duplicate, expired, malformed, or identity-mismatched
 artifacts; child run ids and evidence-reuse provenance come only from the
-validated manifest.
+validated manifest. Repository dispatches must provide the exact parent run
+attempt; manual dispatches may omit it to resolve the current attempt. Schema
+v2 records `runAttempt` on every persisted run while schema v1 remains readable.
+Exact duplicate parent attempts are no-ops, and an older attempt cannot replace
+a newer attempt for the same run id.
 
 Both evidence workflows require an exact package spec and release ref. They
 commit with the workflow's same-repository `github.token`, then verify that the
@@ -129,6 +133,7 @@ gh workflow run openclaw-release-evidence-from-full-validation.yml \
   --repo openclaw/releases \
   --ref main \
   -f full_validation_run_id=24977011361 \
+  -f full_validation_run_attempt=1 \
   -f release_id=2026.4.24 \
   -f release_ref=v2026.4.24 \
   -f package_spec=openclaw@2026.4.24

--- a/scripts/openclaw-release-evidence-contract.mjs
+++ b/scripts/openclaw-release-evidence-contract.mjs
@@ -51,6 +51,19 @@ async function githubJsonOrNull(pathname) {
 export async function githubBinary(url) {
   return request(url, { binary: true });
 }
+export function workflowRunPath(repository, workflowRunId, runAttempt) {
+  const normalizedRunId = runId(workflowRunId, "workflow run id");
+  if (runAttempt === undefined || runAttempt === null || runAttempt === "") {
+    return `/repos/${repository}/actions/runs/${normalizedRunId}`;
+  }
+  return `${workflowRunPath(repository, normalizedRunId)}/attempts/${runId(
+    runAttempt,
+    "workflow run attempt",
+  )}`;
+}
+export function workflowRunJobsPath(repository, workflowRunId, runAttempt) {
+  return `${workflowRunPath(repository, workflowRunId, runAttempt)}/jobs`;
+}
 export async function githubPaged(
   pathname,
   key,
@@ -271,9 +284,13 @@ async function readManifest(artifact) {
 }
 export async function loadFullValidationSource(input) {
   validateReleaseIdentity(input);
-  const parent = await githubJson(`/repos/${PUBLIC_REPO}/actions/runs/${input.fullValidationRunId}`);
+  const parent = await githubJson(
+    workflowRunPath(PUBLIC_REPO, input.fullValidationRunId, input.fullValidationRunAttempt),
+  );
   if (
     String(parent.id) !== String(input.fullValidationRunId) ||
+    (input.fullValidationRunAttempt &&
+      String(parent.run_attempt) !== String(input.fullValidationRunAttempt)) ||
     parent.name !== WORKFLOW ||
     parent.path?.split("@", 1)[0] !== WORKFLOW_PATH ||
     parent.event !== "workflow_dispatch" ||
@@ -281,6 +298,7 @@ export async function loadFullValidationSource(input) {
     parent.conclusion !== "success" ||
     !Number.isInteger(parent.run_attempt) ||
     parent.run_attempt < 1 ||
+    Number.isNaN(Date.parse(parent.updated_at ?? "")) ||
     !SHA.test(parent.head_sha ?? "")
   ) {
     throw new Error(`Full release validation run ${input.fullValidationRunId} is not successful`);
@@ -310,7 +328,8 @@ export async function loadFullValidationSource(input) {
       repo: PUBLIC_REPO, runId: String(parent.id), runAttempt: parent.run_attempt,
       workflowName: parent.name, workflowPath: parent.path,
       workflowRef: parent.head_branch, workflowSha: parent.head_sha,
-      status: parent.status, conclusion: parent.conclusion, htmlUrl: parent.html_url,
+      status: parent.status, conclusion: parent.conclusion, updatedAt: parent.updated_at,
+      htmlUrl: parent.html_url,
     },
     artifact: {
       id: String(artifact.id), name: artifact.name, digest: artifact.digest,
@@ -327,7 +346,10 @@ export function fullValidationRunEntries(source) {
   const child = source.manifest.childRuns;
   const entries = [
     { label: "full-release-validation", runId: source.parentRun.runId, blocking: false,
-      workflowPath: WORKFLOW_PATH },
+      runAttempt: source.parentRun.runAttempt, headSha: source.parentRun.workflowSha,
+      updatedAt: source.parentRun.updatedAt, workflowPath: WORKFLOW_PATH },
+    // Manifest v3 only qualifies the parent attempt. Child attempt pinning needs an
+    // additive upstream protocol field; do not infer it from mutable run state here.
     { label: "normal-ci", runId: child.normalCi, blocking: true, workflowPath: ".github/workflows/ci.yml" },
     { label: "plugin-prerelease", runId: child.pluginPrerelease, blocking: true,
       workflowPath: ".github/workflows/plugin-prerelease.yml" },
@@ -348,6 +370,11 @@ export function fullValidationRunEntries(source) {
 }
 export function validateEvidenceDocument(value, expected, { requireFullValidation = false } = {}) {
   validateReleaseIdentity(expected);
+  const schemaVersion = value?.schemaVersion ?? 1;
+  if (schemaVersion !== 1 && schemaVersion !== 2) {
+    throw new Error("Release evidence schema version is unsupported");
+  }
+  const requiresRunAttempt = schemaVersion >= 2;
   const runs = value?.runs;
   if (
     value?.release?.id !== expected.releaseId ||
@@ -360,7 +387,9 @@ export function validateEvidenceDocument(value, expected, { requireFullValidatio
     runs.some((run) =>
       !run || typeof run.label !== "string" || !run.label ||
       typeof run.repo !== "string" || !run.repo.includes("/") ||
-      !RUN_ID.test(String(run.runId ?? "")) || typeof run.blocking !== "boolean") ||
+      !RUN_ID.test(String(run.runId ?? "")) ||
+      (requiresRunAttempt && !RUN_ID.test(String(run.runAttempt ?? ""))) ||
+      typeof run.blocking !== "boolean") ||
     new Set(runs.map((run) => run.label)).size !== runs.length
   ) {
     throw new Error("Release evidence identity does not match");
@@ -392,6 +421,11 @@ export function validateEvidenceDocument(value, expected, { requireFullValidatio
       expectedRuns.length !== runs.length ||
       expectedRuns.some((entry) => !runs.some((run) =>
         run.label === entry.label && String(run.runId) === entry.runId &&
+        (!requiresRunAttempt ||
+          entry.runAttempt === undefined ||
+          run.runAttempt === entry.runAttempt) &&
+        (entry.headSha === undefined || run.headSha === entry.headSha) &&
+        (entry.updatedAt === undefined || run.updatedAt === entry.updatedAt) &&
         run.repo === entry.repo && run.blocking === entry.blocking &&
         run.path?.split("@", 1)[0] === entry.workflowPath &&
         run.status === "completed" && run.conclusion === "success"))
@@ -400,6 +434,50 @@ export function validateEvidenceDocument(value, expected, { requireFullValidatio
     }
   }
   return value;
+}
+export function classifyFullValidationUpdate(previousEvidence, source, expected) {
+  const previousSource = previousEvidence?.provenance?.fullValidation;
+  if (!previousSource) {
+    return "update";
+  }
+  const previousRunId = String(previousSource.parentRun?.runId ?? "");
+  const currentRunId = String(source.parentRun?.runId ?? "");
+  if (previousRunId !== currentRunId) {
+    return "update";
+  }
+  const previousAttempt = Number(previousSource.parentRun?.runAttempt);
+  const currentAttempt = Number(source.parentRun?.runAttempt);
+  if (!Number.isSafeInteger(previousAttempt) || previousAttempt < 1) {
+    return "update";
+  }
+  if (!Number.isSafeInteger(currentAttempt) || currentAttempt < 1) {
+    throw new Error("Full validation source attempt is invalid");
+  }
+  if (previousAttempt > currentAttempt) {
+    throw new Error(
+      `Refusing to replace Full Release Validation ${currentRunId} attempt ${previousAttempt} with stale attempt ${currentAttempt}`,
+    );
+  }
+  if (previousAttempt === currentAttempt) {
+    if (previousEvidence.schemaVersion !== 2) {
+      return "update";
+    }
+    if (
+      previousSource.parentRun?.workflowSha !== source.parentRun?.workflowSha ||
+      previousSource.parentRun?.updatedAt !== source.parentRun?.updatedAt
+    ) {
+      throw new Error(
+        `Full Release Validation ${currentRunId} attempt ${currentAttempt} identity changed`,
+      );
+    }
+    try {
+      validateEvidenceDocument(previousEvidence, expected, { requireFullValidation: true });
+      return "duplicate";
+    } catch {
+      return "update";
+    }
+  }
+  return "update";
 }
 async function cli() {
   if (process.argv[2] !== "verify-evidence") {

--- a/scripts/openclaw-release-evidence-contract.test.mjs
+++ b/scripts/openclaw-release-evidence-contract.test.mjs
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
+  classifyFullValidationUpdate,
   fullValidationRunEntries,
   githubPaged,
   selectFullValidationArtifact,
   validateEvidenceDocument,
   validateFullValidationManifest,
   validateReleaseIdentity,
+  workflowRunJobsPath,
+  workflowRunPath,
 } from "./openclaw-release-evidence-contract.mjs";
 
 const parentRun = {
@@ -15,6 +18,7 @@ const parentRun = {
   run_attempt: 1,
   head_branch: "release-ci/ebf121af6ab5-1785611218973",
   head_sha: "ebf121af6ab5036beda157722467ef5065ba58c3",
+  updated_at: "2026-08-06T08:00:00Z",
 };
 
 const artifact = {
@@ -72,6 +76,41 @@ const releaseIdentity = {
   resolvedSha: manifest.targetSha,
 };
 
+function persistedEvidence() {
+  const evidence = {
+    schemaVersion: 2,
+    release: {
+      id: releaseIdentity.releaseId,
+      ref: releaseIdentity.releaseRef,
+      packageSpec: releaseIdentity.packageSpec,
+    },
+    provenance: {
+      releaseRef: { status: "resolved", resolvedSha: manifest.targetSha },
+      fullValidation: {
+        releaseIdentity,
+        parentRun: {
+          runId: String(parentRun.id),
+          runAttempt: parentRun.run_attempt,
+          workflowRef: parentRun.head_branch,
+          workflowSha: parentRun.head_sha,
+          updatedAt: parentRun.updated_at,
+        },
+        manifest: validateFullValidationManifest(manifest, parentRun),
+      },
+    },
+    runs: [],
+  };
+  evidence.runs = fullValidationRunEntries(evidence.provenance.fullValidation).map((entry) => ({
+    ...entry,
+    runId: Number(entry.runId),
+    runAttempt: entry.runAttempt ?? 1,
+    path: `${entry.workflowPath}@refs/heads/main`,
+    status: "completed",
+    conclusion: "success",
+  }));
+  return evidence;
+}
+
 test("requires an exact package spec bound to the release id", () => {
   assert.equal(validateReleaseIdentity(releaseIdentity).releaseRef, releaseIdentity.releaseRef);
   assert.throws(
@@ -107,6 +146,29 @@ test("selects one live attempt-qualified artifact", () => {
         parentRun,
       ),
     /identity is invalid/u,
+  );
+});
+
+test("builds exact-attempt workflow run and job API paths", () => {
+  assert.equal(
+    workflowRunPath("openclaw/openclaw", parentRun.id, parentRun.run_attempt),
+    `/repos/openclaw/openclaw/actions/runs/${parentRun.id}/attempts/${parentRun.run_attempt}`,
+  );
+  assert.equal(
+    workflowRunJobsPath("openclaw/openclaw", parentRun.id, parentRun.run_attempt),
+    `/repos/openclaw/openclaw/actions/runs/${parentRun.id}/attempts/${parentRun.run_attempt}/jobs`,
+  );
+  assert.equal(
+    workflowRunPath("other/repository", parentRun.id),
+    `/repos/other/repository/actions/runs/${parentRun.id}`,
+  );
+  assert.equal(
+    workflowRunJobsPath("other/repository", parentRun.id, 2),
+    `/repos/other/repository/actions/runs/${parentRun.id}/attempts/2/jobs`,
+  );
+  assert.equal(
+    workflowRunPath("openclaw/openclaw", parentRun.id),
+    `/repos/openclaw/openclaw/actions/runs/${parentRun.id}`,
   );
 });
 
@@ -161,34 +223,7 @@ test("rejects incomplete GitHub pagination", async () => {
 });
 
 test("revalidates the persisted full-validation evidence identity", () => {
-  const evidence = {
-    release: {
-      id: releaseIdentity.releaseId,
-      ref: releaseIdentity.releaseRef,
-      packageSpec: releaseIdentity.packageSpec,
-    },
-    provenance: {
-      releaseRef: { status: "resolved", resolvedSha: manifest.targetSha },
-      fullValidation: {
-        releaseIdentity,
-        parentRun: {
-          runId: String(parentRun.id),
-          runAttempt: parentRun.run_attempt,
-          workflowRef: parentRun.head_branch,
-          workflowSha: parentRun.head_sha,
-        },
-        manifest: validateFullValidationManifest(manifest, parentRun),
-      },
-    },
-    runs: [],
-  };
-  evidence.runs = fullValidationRunEntries(evidence.provenance.fullValidation).map((entry) => ({
-    ...entry,
-    runId: Number(entry.runId),
-    path: `${entry.workflowPath}@refs/heads/main`,
-    status: "completed",
-    conclusion: "success",
-  }));
+  const evidence = persistedEvidence();
   assert.equal(
     validateEvidenceDocument(evidence, releaseIdentity, { requireFullValidation: true }),
     evidence,
@@ -226,6 +261,81 @@ test("revalidates the persisted full-validation evidence identity", () => {
       ),
     /runs are inconsistent/u,
   );
+  assert.equal(
+    validateEvidenceDocument(
+      {
+        ...evidence,
+        schemaVersion: 1,
+        runs: evidence.runs.map(({ runAttempt: _runAttempt, ...run }) => run),
+      },
+      releaseIdentity,
+      { requireFullValidation: true },
+    ).schemaVersion,
+    1,
+  );
+});
+
+test("deduplicates an exact attempt and rejects attempt rollback", () => {
+  const evidence = persistedEvidence();
+  const source = evidence.provenance.fullValidation;
+  assert.equal(
+    classifyFullValidationUpdate(evidence, source, releaseIdentity),
+    "duplicate",
+  );
+  assert.equal(
+    classifyFullValidationUpdate(
+      {
+        ...evidence,
+        schemaVersion: 1,
+        provenance: {
+          ...evidence.provenance,
+          fullValidation: {
+            ...source,
+            parentRun: {
+              runId: source.parentRun.runId,
+              runAttempt: source.parentRun.runAttempt,
+              workflowRef: source.parentRun.workflowRef,
+              workflowSha: source.parentRun.workflowSha,
+            },
+          },
+        },
+        runs: evidence.runs.map(({ runAttempt: _runAttempt, ...run }) => run),
+      },
+      source,
+      releaseIdentity,
+    ),
+    "update",
+  );
+  assert.equal(
+    classifyFullValidationUpdate(
+      evidence,
+      {
+        ...source,
+        parentRun: { ...source.parentRun, runAttempt: parentRun.run_attempt + 1 },
+        manifest: { ...source.manifest, runAttempt: parentRun.run_attempt + 1 },
+      },
+      releaseIdentity,
+    ),
+    "update",
+  );
+  assert.throws(
+    () =>
+      classifyFullValidationUpdate(
+        {
+          ...evidence,
+          provenance: {
+            ...evidence.provenance,
+            fullValidation: {
+              ...source,
+              parentRun: { ...source.parentRun, runAttempt: parentRun.run_attempt + 1 },
+            },
+          },
+        },
+        source,
+        releaseIdentity,
+      ),
+    /stale attempt/u,
+  );
 });
 
 test("release evidence workflows pin actions and verify the published tree", () => {
@@ -244,6 +354,14 @@ test("release evidence workflows pin actions and verify the published tree", () 
     assert.match(workflow, /group: openclaw-release-evidence-\$\{/u);
     assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/u);
     assert.match(workflow, /environment: release-evidence/u);
+    if (path.includes("from-full-validation")) {
+      assert.match(workflow, /full_validation_run_attempt/u);
+      assert.match(
+        workflow,
+        /repository_dispatch requires a positive full_validation_run_attempt/u,
+      );
+      assert.match(workflow, /--full-validation-run-attempt/u);
+    }
     assert.match(workflow, /generated_tree="\$\(git write-tree\)"[\s\S]*git rev-parse "HEAD:\$\{evidence_path\}"/u);
     assert.match(workflow, /git rev-parse "origin\/main:\$\{evidence_path\}"/u);
   }

--- a/scripts/openclaw-release-evidence-from-full-validation.mjs
+++ b/scripts/openclaw-release-evidence-from-full-validation.mjs
@@ -9,6 +9,7 @@ import {
 } from "./openclaw-release-evidence-contract.mjs";
 const OPTIONS = new Map([
   ["--full-validation-run-id", "fullValidationRunId"],
+  ["--full-validation-run-attempt", "fullValidationRunAttempt"],
   ["--release-id", "releaseId"],
   ["--release-ref", "releaseRef"],
   ["--package-spec", "packageSpec"],
@@ -20,7 +21,7 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === "--help" || argv[index] === "-h") {
       console.log(
-        "Usage: openclaw-release-evidence-from-full-validation.mjs --full-validation-run-id <id> --release-id <version> --release-ref <ref> --package-spec <spec> [--notes-file <file>] [--output-root <dir>]",
+        "Usage: openclaw-release-evidence-from-full-validation.mjs --full-validation-run-id <id> [--full-validation-run-attempt <attempt>] --release-id <version> --release-ref <ref> --package-spec <spec> [--notes-file <file>] [--output-root <dir>]",
       );
       process.exit(0);
     }
@@ -32,6 +33,12 @@ function parseArgs(argv) {
   }
   if (!/^[1-9][0-9]*$/u.test(args.fullValidationRunId ?? "")) {
     throw new Error("--full-validation-run-id must be numeric");
+  }
+  if (
+    args.fullValidationRunAttempt !== undefined &&
+    !/^[1-9][0-9]*$/u.test(args.fullValidationRunAttempt)
+  ) {
+    throw new Error("--full-validation-run-attempt must be a positive integer");
   }
   return args;
 }
@@ -45,7 +52,9 @@ async function main() {
   await fs.writeFile(
     runsFile,
     `${fullValidationRunEntries(source)
-      .map((entry) => `${entry.label} ${entry.repo} ${entry.runId} ${entry.blocking ? "blocking" : "advisory"}`)
+      .map((entry) =>
+        `${entry.label} ${entry.repo} ${entry.runId} ${entry.blocking ? "blocking" : "advisory"}`,
+      )
       .join("\n")}\n`,
   );
   await fs.writeFile(sourceFile, `${JSON.stringify(source, null, 2)}\n`);

--- a/scripts/openclaw-release-evidence.mjs
+++ b/scripts/openclaw-release-evidence.mjs
@@ -4,12 +4,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  classifyFullValidationUpdate,
   githubBinary,
   githubJson,
   githubPaged,
   resolvePublicRelease,
   resolveReleaseRef,
   validateEvidenceDocument,
+  workflowRunJobsPath,
+  workflowRunPath,
 } from "./openclaw-release-evidence-contract.mjs";
 
 const DEFAULT_EVIDENCE_REPO = "openclaw/releases";
@@ -351,6 +354,7 @@ function normalizeRun(run, entry, jobs, artifacts) {
     label: entry.label,
     repo: entry.repo,
     runId: Number(entry.runId),
+    runAttempt: run.run_attempt,
     blocking: entry.blocking,
     status: run.status,
     conclusion: run.conclusion,
@@ -986,19 +990,53 @@ async function main() {
   const previousEvidence = await readPreviousEvidence(
     path.join(outputDir, "release-evidence.json"),
   );
+  if (
+    fullValidation &&
+    classifyFullValidationUpdate(previousEvidence, fullValidation, {
+      releaseId: args.releaseId,
+      releaseRef: args.releaseRef,
+      packageSpec: args.packageSpec,
+    }) === "duplicate"
+  ) {
+    console.log(
+      `Evidence ${args.releaseId} already records Full Release Validation ${fullValidation.parentRun.runId} attempt ${fullValidation.parentRun.runAttempt}`,
+    );
+    return;
+  }
 
   const runs = [];
   for (const entry of runEntries) {
     const [owner, repoName] = entry.repo.split("/");
-    const run = await githubJson(`/repos/${owner}/${repoName}/actions/runs/${entry.runId}`);
+    const exactParent =
+      fullValidation &&
+      entry.label === "full-release-validation" &&
+      entry.repo === "openclaw/openclaw" &&
+      String(entry.runId) === String(fullValidation.parentRun.runId);
+    const runAttempt = exactParent ? fullValidation.parentRun.runAttempt : undefined;
+    const run = await githubJson(workflowRunPath(entry.repo, entry.runId, runAttempt));
+    if (runAttempt && run.run_attempt !== runAttempt) {
+      throw new Error(
+        `Run ${entry.repo} ${entry.runId} attempt mismatch: expected ${runAttempt}, got ${run.run_attempt}`,
+      );
+    }
     const jobs = await githubPaged(
-      `/repos/${owner}/${repoName}/actions/runs/${entry.runId}/jobs`,
+      workflowRunJobsPath(entry.repo, entry.runId, runAttempt),
       "jobs",
     );
-    const artifacts = await githubPaged(
+    let artifacts = await githubPaged(
       `/repos/${owner}/${repoName}/actions/runs/${entry.runId}/artifacts`,
       "artifacts",
     );
+    if (exactParent) {
+      artifacts = artifacts.filter(
+        (artifact) => String(artifact.id) === String(fullValidation.artifact.id),
+      );
+      if (artifacts.length !== 1) {
+        throw new Error(
+          `Full validation artifact ${fullValidation.artifact.id} is not uniquely available`,
+        );
+      }
+    }
     const normalized = normalizeRun(run, entry, jobs, artifacts);
     runs.push(normalized);
   }
@@ -1010,7 +1048,7 @@ async function main() {
   }
 
   const evidence = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     generatedBy: {
       repository: process.env.GITHUB_REPOSITORY || DEFAULT_EVIDENCE_REPO,


### PR DESCRIPTION
## Summary

- require `full_validation_run_attempt` on repository-dispatched evidence ingestion
- read the exact parent workflow attempt and attempt-qualified jobs
- persist `runAttempt` in schema-v2 run records while retaining schema-v1 readability
- make exact duplicate attempts no-ops and reject stale attempt rollback
- bind the parent record to its exact manifest artifact, SHA, and completion timestamp

## Why

This is the downstream receiver contract for:

- https://github.com/openclaw/openclaw/pull/120032

The OpenClaw publisher confirms durable release evidence by exact Full Release
Validation run ID and attempt. The releases ledger previously discarded the
attempt and could resolve mutable current-attempt state instead.

## Dependency

Stacked on:

- https://github.com/openclaw/releases/pull/14

That PR owns the hardened manifest-based release-evidence receiver. This PR is
only the exact-attempt persistence and idempotency delta.

## Rollout

1. Merge https://github.com/openclaw/releases/pull/14.
2. Merge https://github.com/openclaw/openclaw/pull/120032. Its added payload
   field is ignored safely by the receiver from step 1.
3. Merge this PR, which then requires and persists the field.
4. Prove one exact cross-repository dispatch before closing release validation.

## Validation

- `node --test scripts/openclaw-release-evidence-contract.test.mjs` (8 passed)
- `node --check` on all three evidence scripts
- `actionlint -shellcheck= -pyflakes=` on the receiver workflow
- `yamllint` with the repository's existing workflow style allowances
- `git diff --check`
- read-only live ingest of Full Release Validation run `30714067986`, attempt `1`
  - schema v2 persisted `runAttempt: 1`
  - parent stored exactly one `full-release-validation-30714067986-1` artifact
  - repeated ingest was byte-identical and produced no update
- local autoreview through P2: clean
- local ClawSweeper at `64afaa739e0b41097de700ac24717bafb8a868a6`
  - high-confidence `keep_open`
  - no code or security findings

## Compatibility

- manual workflow dispatch keeps the attempt input optional and resolves the
  current attempt when omitted
- repository dispatch requires the exact attempt supplied by the current sender
- schema-v1 evidence remains verifiable; an exact retry upgrades it to schema v2
- child workflow attempts remain outside this delta because the upstream v3
  manifest currently supplies child run IDs only

## Punchcard

Commit trailer: `Punchcard-Session: coral-meadow-meadow-8y`

Attestation could not be recorded because that active session is registered to
`openclaw/openclaw`; Punchcard returned `INVALID_INPUT` for this
`openclaw/releases` commit.
