### PR TITLE
fix(macos): prepare releases with current native validation

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -46,8 +46,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  NODE_VERSION: "24.x"
-  PNPM_VERSION: "10.23.0"
+  NODE_VERSION: "24.19.0"
   OPENCLAW_REPOSITORY: openclaw/openclaw
   EXPECTED_DEVELOPER_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)"
   EXPECTED_DEVELOPER_TEAM_ID: FWJYW4S8P8
@@ -133,7 +132,7 @@ jobs:
   build_sign_and_package:
     needs: prepare
     if: ${{ needs.prepare.outputs.reuse_preflight != 'true' }}
-    runs-on: macos-15
+    runs-on: macos-26
     # Match npm-release: signing and notarization stay behind the mac-release
     # environment's required release-manager approval gate.
     environment: mac-release
@@ -148,6 +147,7 @@ jobs:
         run: |
           set -euo pipefail
           git clone https://github.com/openclaw/openclaw.git source
+          git -C source rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null
           if [[ -z "${SOURCE_REF}" ]]; then
             git -C source checkout --detach "refs/tags/${RELEASE_TAG}"
             exit 0
@@ -181,7 +181,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
+          package_json_file: source/package.json
           run_install: false
 
       - name: Setup Node.js
@@ -197,9 +197,9 @@ jobs:
           CI: "true"
         run: pnpm install --frozen-lockfile
 
-      - name: Select Xcode 26.1
+      - name: Select release toolchain
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app
+          sudo xcode-select -s /Applications/Xcode_26.6.app
           xcodebuild -version
           swift --version
 
@@ -210,12 +210,6 @@ jobs:
           key: ${{ runner.os }}-swiftpm-release-${{ hashFiles('source/apps/macos/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swiftpm-release-
-
-      - name: Ensure matching public GitHub release exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.tag }}
-        run: gh release view "$RELEASE_TAG" --repo "$OPENCLAW_REPOSITORY" >/dev/null
 
       - name: Resolve package version
         id: package_version

--- a/.github/workflows/openclaw-macos-validate.yml
+++ b/.github/workflows/openclaw-macos-validate.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   macos_validate:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
     permissions:
       contents: read
@@ -37,12 +37,6 @@ jobs:
             exit 1
           fi
 
-      - name: Ensure matching public GitHub release exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.tag }}
-        run: gh release view "$RELEASE_TAG" --repo "$OPENCLAW_REPOSITORY" >/dev/null
-
       - name: Clone selected public source
         env:
           RELEASE_TAG: ${{ inputs.tag }}
@@ -50,6 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           git clone https://github.com/openclaw/openclaw.git source
+          git -C source rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null
           if [[ -z "${SOURCE_REF}" ]]; then
             git -C source checkout --detach "refs/tags/${RELEASE_TAG}"
             exit 0
@@ -80,11 +75,17 @@ jobs:
           done
           exit 1
 
-      - name: Select Xcode 26.1
+      - name: Select release toolchain
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app
+          set -euo pipefail
+          sudo xcode-select -s /Applications/Xcode_26.6.app
           xcodebuild -version
           swift --version
+
+      - name: Setup Node.js for native test isolation
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.19.0"
 
       - name: Cache SwiftPM
         uses: actions/cache@v5
@@ -98,63 +99,13 @@ jobs:
         working-directory: source
         run: |
           set -euo pipefail
-          python3 <<'PY'
-          import re
-          import subprocess
-          import sys
-
-          command = ["swift", "test", "--package-path", "apps/macos", "--no-parallel"]
-          timeout_seconds = 900
-          timed_out = False
-
-          try:
-              completed = subprocess.run(
-                  command,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.STDOUT,
-                  text=True,
-                  timeout=timeout_seconds,
-              )
-              output = completed.stdout or ""
-              returncode = completed.returncode
-          except subprocess.TimeoutExpired as exc:
-              timed_out = True
-              output = exc.stdout or ""
-              if isinstance(output, bytes):
-                  output = output.decode(errors="replace")
-              returncode = 124
-
-          print(output, end="", flush=True)
-
-          passed_tests = len(re.findall(r"✔ Test ", output))
-          passed_suites = len(re.findall(r"✔ Suite ", output))
-          failed_tests = len(re.findall(r"✘ Test ", output))
-          failed_suites = len(re.findall(r"✘ Suite ", output))
-          build_errors = [
-              line for line in output.splitlines()
-              if re.search(r":\d+:\d+: error:", line.lower())
-              or line.strip().lower().startswith(("error:", "fatal error:"))
-          ]
-
-          if returncode == 0:
-              sys.exit(0)
-
-          if timed_out and failed_tests == 0 and failed_suites == 0 and not build_errors and passed_tests >= 80 and passed_suites >= 15:
-              print(
-                  f"::warning::swift test timed out after {timeout_seconds}s with "
-                  f"{passed_tests} passed tests and {passed_suites} passed suites; "
-                  "accepting known Swift Testing runner hang after no failures."
-              )
-              sys.exit(0)
-
-          print(
-              f"swift test failed: returncode={returncode} timed_out={timed_out} "
-              f"passed_tests={passed_tests} passed_suites={passed_suites} "
-              f"failed_tests={failed_tests} failed_suites={failed_suites} build_errors={len(build_errors)}",
-              file=sys.stderr,
-          )
-          sys.exit(returncode or 124)
-          PY
+          # Match the product CI launcher: isolated resources and a completed
+          # suite are required; partial output from a timeout is never proof.
+          swift_test_args=(--package-path apps/macos --build-system native --enable-code-coverage)
+          swift build "${swift_test_args[@]}" --build-tests
+          swift_test_args+=(--skip-build --no-parallel)
+          node scripts/test-macos-native.mts default "${swift_test_args[@]}" --skip AppStateIsolationTests
+          node scripts/test-macos-native.mts named "${swift_test_args[@]}" --filter AppStateIsolationTests
 
       - name: Capture validation provenance
         id: validation_provenance
@@ -187,7 +138,7 @@ jobs:
             echo "## macOS validation"
             echo
             echo "- Tag: \`${RELEASE_TAG}\`"
-            echo "- Validation: \`swift test --package-path apps/macos --no-parallel\`"
+            echo "- Validation: \`scripts/test-macos-native.mts\` (default and named profiles, complete serial suite)"
             echo "- Validation proof artifact: \`macos-validate-${RELEASE_TAG}\`"
             echo
             echo "This lane is release-blocking validation, but it does not build, sign, notarize, package, or upload release artifacts."

--- a/tests/test_macos_workflows.py
+++ b/tests/test_macos_workflows.py
@@ -1,0 +1,75 @@
+"""Exercise macOS release workflow failure propagation without Apple services."""
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow(name):
+    return (ROOT / '.github/workflows' / name).read_text()
+
+
+def step_script(source, name):
+    step = source.split(f'      - name: {name}\n', 1)[1].split('\n      - name:', 1)[0]
+    script = step.split('        run: |\n', 1)[1]
+    return '\n'.join(line[10:] for line in script.splitlines()) + '\n'
+
+
+class MacOSWorkflowTests(unittest.TestCase):
+    def test_complete_isolated_suite_and_failure_propagation(self):
+        script = step_script(workflow('openclaw-macos-validate.yml'), 'Swift test')
+        # A failed build, failed profile, or timed-out profile must never upload
+        # successful validation proof or proceed to later test profiles.
+        for failed_phase, exit_code, expected in [
+            ('', 0, ['build', 'default', 'named']),
+            ('build', 1, ['build']),
+            ('default', 124, ['build', 'default']),
+            ('named', 1, ['build', 'default', 'named']),
+        ]:
+            with self.subTest(failed_phase=failed_phase), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                stub = '#!/usr/bin/env python3\n' + (
+                    'import json,os,sys\n'
+                    'phase="build" if sys.argv[0].endswith("swift") else sys.argv[2]\n'
+                    'with open(os.environ["CALLS"],"a") as f: f.write(json.dumps({"phase":phase,"args":sys.argv[1:]})+"\\n")\n'
+                    'sys.exit(int(os.environ["FAIL_CODE"]) if phase==os.environ["FAIL_PHASE"] else 0)\n'
+                )
+                for binary in ['swift', 'node']:
+                    path = root / binary
+                    path.write_text(stub)
+                    path.chmod(0o755)
+                env = dict(os.environ, PATH=f'{root}:{os.environ["PATH"]}',
+                           CALLS=str(root / 'calls'), FAIL_PHASE=failed_phase, FAIL_CODE=str(exit_code))
+                result = subprocess.run(['bash', '-c', script], env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode, exit_code, result.stderr)
+                calls = [json.loads(line) for line in (root / 'calls').read_text().splitlines()]
+                self.assertEqual([call['phase'] for call in calls], expected)
+                for call in calls[1:]:
+                    self.assertEqual(call['args'][0], 'scripts/test-macos-native.mts')
+                    self.assertIn('--skip-build', call['args'])
+                    self.assertIn('--no-parallel', call['args'])
+                if len(calls) == 3:
+                    self.assertEqual(calls[1]['args'][-2:], ['--skip', 'AppStateIsolationTests'])
+                    self.assertEqual(calls[2]['args'][-2:], ['--filter', 'AppStateIsolationTests'])
+
+    def test_preparation_needs_tag_but_release_page_only_for_promotion(self):
+        publish = workflow('openclaw-macos-publish.yml')
+        validate = workflow('openclaw-macos-validate.yml')
+        build, promote = publish.split('  promote_release_artifacts:', 1)
+        for preparation in [build, validate]:
+            self.assertNotIn('gh release view', preparation)
+            clone = step_script(preparation, 'Clone selected public source')
+            self.assertIn('git -C source rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}"', clone)
+        self.assertIn('gh release view', promote)
+        self.assertIn('environment: mac-release', build)
+        self.assertIn('environment: mac-release', promote)
+        self.assertIn('if: ${{ !inputs.preflight_only && !inputs.smoke_test_only }}', promote)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
macOS preparation currently requires the public GitHub Release before it can validate or produce signed assets. It also selects Xcode 26.1 and pnpm 10.23.0, while the 2026.8.1 source needs Swift 6.3 and pins pnpm 12.1.0. The validation lane can incorrectly return success when Swift times out after only a partial suite.

Keep existing-tag validation, but require the GitHub Release page only during actual promotion. Prepare with macos-26/Xcode 26.6 and the source packageManager pin. Build the tests and run both complete profiles through the product's existing native isolation launcher; a build, test, or timeout failure now stops proof generation. Signing and promotion retain their independent protected mac-release approval gates.

Validation: executable workflow boundary tests pass for success, build failure, default-profile timeout, and named-profile failure. The same tests fail on the previous workflow; the old timeout-success bug was separately reproduced. Structural actionlint and git diff checks pass; the seven pre-existing shellcheck notices are unchanged. Independent Codex review is scoped-clean. Tooling changes remove 55 lines net; the added tests cover release and failure-propagation contracts. Final signed artifact and native-suite proof will run against the exact release tag.
