### PR TITLE
chore(deps): refresh release actions and add repository CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            pnpm: "10.33.0"
+          - os: macos-26
+            pnpm: "12.1.0"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Prepare package-manager fixture
+        env:
+          PNPM_VERSION: ${{ matrix.pnpm }}
+        run: |
+          mkdir -p .git/action-proof/source
+          printf '{"private":true,"packageManager":"pnpm@%s"}\n' "$PNPM_VERSION" > .git/action-proof/source/package.json
+
+      - name: Setup pnpm from source manifest
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: .git/action-proof/source/package.json
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24.20.0"
+
+      - name: Check scripts
+        run: |
+          node --check scripts/openclaw-release-evidence.mjs
+          node --check scripts/openclaw-release-evidence-from-full-validation.mjs
+
+      - name: Run workflow regression tests
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python3 -m unittest discover -s tests -v
+
+      - name: Exercise selected package manager
+        working-directory: .git/action-proof/source
+        env:
+          PNPM_VERSION: ${{ matrix.pnpm }}
+        run: |
+          node --version
+          pnpm --version
+          test "$(pnpm --version)" = "$PNPM_VERSION"
+          pnpm install --lockfile-only
+          pnpm install --frozen-lockfile
+          pnpm store path
+
+      - name: Prepare action round-trip proof
+        run: |
+          mkdir -p "$RUNNER_TEMP/action-proof"
+          printf 'release action round-trip proof\n' > "$RUNNER_TEMP/action-proof/proof.txt"
+
+      - name: Save proof cache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ runner.temp }}/action-proof
+          key: release-ci-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Remove local cache input
+        run: rm "$RUNNER_TEMP/action-proof/proof.txt"
+
+      - name: Restore proof cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}/action-proof
+          key: release-ci-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
+
+      - name: Upload restored proof
+        uses: actions/upload-artifact@v7
+        with:
+          name: action-proof-${{ runner.os }}
+          path: ${{ runner.temp }}/action-proof/proof.txt
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Download proof
+        uses: actions/download-artifact@v8
+        with:
+          name: action-proof-${{ runner.os }}
+          path: ${{ runner.temp }}/action-proof-downloaded
+
+      - name: Verify round-trip content
+        run: |
+          printf 'release action round-trip proof\n' | diff - "$RUNNER_TEMP/action-proof-downloaded/proof.txt"
+          echo "Cache and artifact round trips passed."

--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -46,7 +46,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  NODE_VERSION: "24.19.0"
+  NODE_VERSION: "24.20.0"
   OPENCLAW_REPOSITORY: openclaw/openclaw
   EXPECTED_DEVELOPER_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)"
   EXPECTED_DEVELOPER_TEAM_ID: FWJYW4S8P8
@@ -179,13 +179,13 @@ jobs:
           exit 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: source/package.json
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -204,7 +204,7 @@ jobs:
           swift --version
 
       - name: Cache SwiftPM
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-swiftpm-release-${{ hashFiles('source/apps/macos/Package.resolved') }}

--- a/.github/workflows/openclaw-macos-validate.yml
+++ b/.github/workflows/openclaw-macos-validate.yml
@@ -83,12 +83,12 @@ jobs:
           swift --version
 
       - name: Setup Node.js for native test isolation
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "24.19.0"
+          node-version: "24.20.0"
 
       - name: Cache SwiftPM
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-swiftpm-release-${{ hashFiles('source/apps/macos/Package.resolved') }}

--- a/.github/workflows/openclaw-npm-dist-tags.yml
+++ b/.github/workflows/openclaw-npm-dist-tags.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -262,7 +262,7 @@ jobs:
           echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -362,7 +362,7 @@ jobs:
           echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/openclaw-release-evidence-from-full-validation.yml
+++ b/.github/workflows/openclaw-release-evidence-from-full-validation.yml
@@ -51,13 +51,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout release repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/openclaw-release-evidence.yml
+++ b/.github/workflows/openclaw-release-evidence.yml
@@ -43,13 +43,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout release repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ maintenance, and durable release evidence separate from the product source repo.
 
 ## Workflows
 
+- `.github/workflows/ci.yml` checks the repository scripts, runs workflow
+  regression tests, and verifies package-manager setup plus cache/artifact round
+  trips on Linux and macOS for pull requests and pushes to `main`. It uses a
+  read-only repository token and temporary fixtures; it does not publish releases
+  or update the evidence ledger.
 - `.github/workflows/openclaw-macos-validate.yml` runs the release-blocking macOS
   Swift test lane for an existing OpenClaw tag.
 - `.github/workflows/openclaw-macos-publish.yml` prepares and promotes signed
@@ -31,6 +36,15 @@ maintenance, and durable release evidence separate from the product source repo.
 The macOS publish workflow builds from public `openclaw/openclaw` tags and uses
 the public repo's packaging scripts. Real publish runs promote previously
 prepared artifacts rather than rebuilding during the final upload step.
+
+The scripts use only Node.js built-ins and require no dependency installation or
+build step. Run local checks with Node.js 24 and Python 3:
+
+```bash
+node --check scripts/openclaw-release-evidence.mjs
+node --check scripts/openclaw-release-evidence-from-full-validation.mjs
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
+```
 
 ## Release Approval
 


### PR DESCRIPTION
Release automation was using older action majors and had no pull-request CI for this repository's scripts or workflow regression tests. Refresh the actions and add Linux/macOS checks that also exercise pnpm setup and real cache/artifact round trips using temporary fixtures and a read-only repository token.

Dependency changes:

- `actions/checkout`: v6 → v7 (currently v7.0.1). [Migration notes](https://github.com/actions/checkout/releases/tag/v7.0.0): ESM and safer fork handling for privileged triggers; the evidence workflows use dispatch triggers and retain checkout-managed credentials.
- `actions/setup-node`: v6 → v7 (v7.0.0). [Migration notes](https://github.com/actions/setup-node/releases/tag/v7.0.0): ESM and removal of the dummy auth-token export; publishing steps already supply their token explicitly.
- `actions/cache`: v5 → v6 (currently v6.1.0). [Migration notes](https://github.com/actions/cache/releases/tag/v6.0.0): ESM and toolkit updates; hosted runners support the Node 24 action runtime.
- `pnpm/action-setup`: v4 → v6 (currently v6.0.10), retaining `package_json_file` and `run_install: false`. v5 moved to Node 24; v6 added newer pnpm support. CI exercises pnpm 10.33.0 and the product's current 12.1.0 without changing the package manager selected by any release tag.
- Pinned macOS Node.js: 24.19.0 → 24.20.0, the latest Node 24 LTS release. Floating `24.x` lanes stay on that LTS line.
- `actions/upload-artifact@v7` and `actions/download-artifact@v8` already resolve to the latest stable releases (7.0.1 and 8.0.1). No application dependency manifests or lockfiles exist here; both JavaScript entrypoints use only Node built-ins. No dependencies were added or removed, and no action majors were skipped.

Validation:

```text
.git/deps-refresh-20260830/node-v24.20.0-darwin-arm64/bin/node --version
v24.20.0

.git/deps-refresh-20260830/node-v24.20.0-darwin-arm64/bin/node --check scripts/openclaw-release-evidence.mjs
.git/deps-refresh-20260830/node-v24.20.0-darwin-arm64/bin/node --check scripts/openclaw-release-evidence-from-full-validation.mjs
# Both exit 0; no build step is required for these dependency-free scripts.

PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
Ran 2 tests in 7.572s
OK

actionlint -shellcheck=
actionlint .github/workflows/ci.yml
git diff --check
# All exit 0. Existing release-publish shellcheck diagnostics predate this patch;
# full actionlint including shellcheck passes for the new CI workflow.
```

Live proof used the downloaded, checksum-verified Node 24.20.0 binary against a real completed GitHub run and published npm package. GitHub's anonymous quota was exhausted, so the existing `gh` session token was injected into the child process environment without printing or saving it. Exact child command and output:

```text
.git/deps-refresh-20260830/node-v24.20.0-darwin-arm64/bin/node scripts/openclaw-release-evidence.mjs --release-id deps-refresh-20260830 --runs-file .git/deps-refresh-20260830/runs.txt --package-spec openclaw@2026.8.1 --output-root .git/deps-refresh-20260830/proof
Wrote .git/deps-refresh-20260830/proof/deps-refresh-20260830/release-evidence.md
Wrote .git/deps-refresh-20260830/proof/deps-refresh-20260830/release-evidence.json
```

The input file contained `macos-validate openclaw/releases 33347963433 blocking`. Assertions against the generated JSON verified the run ID, success conclusion, published package version, and nonempty tarball/integrity fields:

```json
{
  "runId": 33347963433,
  "conclusion": "success",
  "jobs": 1,
  "npmVersion": "2026.8.1",
  "npmStatus": "published"
}
```

CI diagnosis:

- The reported red state is historical release-operations failure, not a current repository build/test failure. [Evidence run 33210441933](https://github.com/openclaw/releases/actions/runs/33210441933) failed pushing evidence with `Invalid username or token`. Commit [1e02ce6](https://github.com/openclaw/releases/commit/1e02ce6379b65115a2aac9be4a48022f20cf46c1) already replaced that token path with checkout-managed job credentials. [Later evidence run 33342760696](https://github.com/openclaw/releases/actions/runs/33342760696) succeeded.
- [macOS validation 33347963433](https://github.com/openclaw/releases/actions/runs/33347963433) passed on current main. This is release-blocking product validation.
- [Scheduled npm operations 33360501425](https://github.com/openclaw/releases/actions/runs/33360501425) passed on current main. This is an operational workflow, not repository build/test CI.
- [macOS publish 33347963843](https://github.com/openclaw/releases/actions/runs/33347963843) was cancelled during release-content verification after its build passed. It has not been rerun; signing, publication, production state, and credentials are outside this maintenance PR.
- The new `CI` workflow is the repository's push/PR build-check and test lane. Its action compatibility checks preserve assertion failures and use separate synthetic cache keys and artifacts.

Codex Autoreview completed with `scoped-clean`, no accepted/actionable findings at its default P0 threshold. No changelog change: this is internal automation/toolchain maintenance. The orchestrator owns review and merge.

PR CI result: [run 33362470626](https://github.com/openclaw/releases/actions/runs/33362470626) passed on commit `e71c1d1c99416dd0558c0b6559d4c37ea7bc6665`. Linux/pnpm 10.33.0 completed in 20 seconds and macOS/pnpm 12.1.0 in 23 seconds. Both jobs passed syntax checks, the full existing regression suite, real package-manager installation, cache save/restore, and artifact upload/download with exact content verification. No failed job or retry occurred in this PR run.
