### PR TITLE
fix(macos): resume notarization from verified release checkpoints

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -29,6 +29,14 @@ on:
         description: Existing successful mac validate workflow run id to prove the required swift test gate passed for this tag
         required: false
         type: string
+      resume_notarization_run_id:
+        description: Failed signed preflight run containing a notarization recovery checkpoint; resumes without compiling the app again
+        required: false
+        type: string
+      resume_notarization_run_attempt:
+        description: Exact attempt of the failed preflight that uploaded the recovery checkpoint
+        required: false
+        type: string
       allow_late_calver_recovery:
         description: Allow mac-only recovery after the npm CalVer freshness window, while still verifying the published npm package exists
         required: true
@@ -60,6 +68,27 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Validate notarization recovery inputs
+        env:
+          RESUME_RUN_ID: ${{ inputs.resume_notarization_run_id }}
+          RESUME_RUN_ATTEMPT: ${{ inputs.resume_notarization_run_attempt }}
+          PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
+          SMOKE_TEST_ONLY: ${{ inputs.smoke_test_only }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RESUME_RUN_ID" && -z "$RESUME_RUN_ATTEMPT" ]]; then
+            exit 0
+          fi
+          if [[ ! "$RESUME_RUN_ID" =~ ^[1-9][0-9]*$ || ! "$RESUME_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Recovery requires a positive run id and exact run attempt." >&2
+            exit 1
+          fi
+          if [[ "$PREFLIGHT_ONLY" != true || "$SMOKE_TEST_ONLY" != false || "$WORKFLOW_REF" != refs/heads/main ]]; then
+            echo "Notarization recovery requires a signed preflight dispatched from main." >&2
+            exit 1
+          fi
+
       - name: Validate tag input format
         env:
           RELEASE_TAG: ${{ inputs.tag }}
@@ -165,6 +194,7 @@ jobs:
           git -C source checkout --detach "refs/remotes/origin/${SOURCE_REF}"
 
       - name: Checkout submodules (retry)
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         run: |
           set -euo pipefail
@@ -179,6 +209,7 @@ jobs:
           exit 1
 
       - name: Setup pnpm
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         uses: pnpm/action-setup@v6
         with:
           package_json_file: source/package.json
@@ -188,10 +219,11 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          cache: ${{ inputs.resume_notarization_run_id == '' && 'pnpm' || '' }}
           cache-dependency-path: source/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         env:
           CI: "true"
@@ -204,6 +236,7 @@ jobs:
           swift --version
 
       - name: Cache SwiftPM
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         uses: actions/cache@v6
         with:
           path: ~/Library/Caches/org.swift.swiftpm
@@ -231,7 +264,87 @@ jobs:
             echo "is_beta=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify notarization checkpoint producer
+        if: ${{ inputs.resume_notarization_run_id != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESUME_RUN_ID: ${{ inputs.resume_notarization_run_id }}
+          RESUME_RUN_ATTEMPT: ${{ inputs.resume_notarization_run_attempt }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RESUME_RUN_ID}/attempts/${RESUME_RUN_ATTEMPT}" > "$RUNNER_TEMP/notarization-producer.json"
+          node <<'NODE'
+          const fs = require('node:fs');
+          const run = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/notarization-producer.json`, 'utf8'));
+          const expected = {
+            id: Number(process.env.RESUME_RUN_ID), run_attempt: Number(process.env.RESUME_RUN_ATTEMPT),
+            path: '.github/workflows/openclaw-macos-publish.yml', head_branch: 'main',
+            event: 'workflow_dispatch', status: 'completed',
+          };
+          for (const [key, value] of Object.entries(expected)) {
+            if (run[key] !== value) throw new Error(`Recovery producer ${key} must equal ${value}`);
+          }
+          if (run.repository?.full_name !== process.env.GITHUB_REPOSITORY ||
+              !['failure', 'cancelled'].includes(run.conclusion) || !/^[a-f0-9]{40}$/.test(run.head_sha)) {
+            throw new Error('Recovery requires a failed or cancelled signed preflight in this repository');
+          }
+          NODE
+
+      - name: Download notarization checkpoint
+        if: ${{ inputs.resume_notarization_run_id != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-notarization-${{ inputs.tag }}-${{ inputs.resume_notarization_run_id }}-${{ inputs.resume_notarization_run_attempt }}
+          path: source/dist/macos-notarization-recovery
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.resume_notarization_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify notarization checkpoint release binding
+        id: recovery_verified
+        if: ${{ inputs.resume_notarization_run_id != '' }}
+        working-directory: source
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          PUBLIC_RELEASE_BRANCH: ${{ inputs.public_release_branch }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f scripts/lib/mac-notarization-recovery.py ]] || ! grep -Fq -- '--resume-notarization' scripts/package-mac-dist.sh; then
+            echo "Selected source does not support notarization recovery. Refusing to rebuild; use source containing the recovery interface." >&2
+            exit 1
+          fi
+          if [[ "$PUBLIC_RELEASE_BRANCH" != main && ! "$PUBLIC_RELEASE_BRANCH" =~ ^release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]]; then
+            echo "Invalid public release branch." >&2
+            exit 1
+          fi
+          git fetch --no-tags origin "+refs/heads/${PUBLIC_RELEASE_BRANCH}:refs/remotes/origin/${PUBLIC_RELEASE_BRANCH}"
+          git merge-base --is-ancestor "refs/tags/${RELEASE_TAG}^{commit}" HEAD
+          git merge-base --is-ancestor HEAD "refs/remotes/origin/${PUBLIC_RELEASE_BRANCH}"
+          node <<'NODE'
+          const fs = require('node:fs');
+          const { execFileSync } = require('node:child_process');
+          const root = 'dist/macos-notarization-recovery';
+          const envelope = JSON.parse(fs.readFileSync(`${root}/workflow-release.json`, 'utf8'));
+          const manifest = JSON.parse(fs.readFileSync(`${root}/manifest.json`, 'utf8'));
+          const producer = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/notarization-producer.json`, 'utf8'));
+          const sourceSha = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+          const version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+          const expected = { releaseTag: process.env.RELEASE_TAG, sourceSha, producerRunId: producer.id,
+            producerRunAttempt: producer.run_attempt, producerWorkflowSha: producer.head_sha,
+            preflightOnly: true, smokeTestOnly: false };
+          for (const [key, value] of Object.entries(expected)) {
+            if (envelope[key] !== value) throw new Error(`Recovery checkpoint ${key} mismatch`);
+          }
+          if (manifest.schemaVersion !== 1 || manifest.sourceSha !== sourceSha || manifest.version !== version ||
+              manifest.skipDmg !== false || manifest.skipDsym !== false) {
+            throw new Error('Recovery checkpoint source, version or release packaging flags mismatch');
+          }
+          NODE
+          python3 scripts/lib/mac-notarization-recovery.py verify dist/macos-notarization-recovery \
+            "$(git rev-parse HEAD)" "$(node -p "require('./package.json').version")" >/dev/null
+
       - name: Release packaging guards
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         env:
           NODE_OPTIONS: --max-old-space-size=4096
@@ -242,12 +355,14 @@ jobs:
           pnpm check:host-env-policy:swift
 
       - name: Build
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         env:
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm build
 
       - name: Build Control UI if missing
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         run: |
           set -euo pipefail
@@ -258,6 +373,7 @@ jobs:
           node scripts/ui.js build
 
       - name: Validate release tag and package metadata
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         env:
           ALLOW_LATE_CALVER_RECOVERY: ${{ inputs.allow_late_calver_recovery }}
@@ -294,6 +410,7 @@ jobs:
           echo "::warning::Allowing late mac-only recovery for ${RELEASE_TAG}; published npm metadata for openclaw@${package_version} is present."
 
       - name: Verify release contents
+        if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         env:
           NODE_OPTIONS: --max-old-space-size=4096
@@ -406,6 +523,7 @@ jobs:
           echo "SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build, sign, notarize, and package macOS release
+        id: package_release
         if: ${{ !inputs.smoke_test_only }}
         working-directory: source
         env:
@@ -417,7 +535,81 @@ jobs:
           SKIP_TSC: "1"
           SKIP_UI_BUILD: "1"
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
-        run: scripts/package-mac-dist.sh
+          RESUME_RUN_ID: ${{ inputs.resume_notarization_run_id }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$RESUME_RUN_ID" ]]; then
+            scripts/package-mac-dist.sh --resume-notarization
+          else
+            scripts/package-mac-dist.sh
+          fi
+
+      - name: Preserve notarization recovery checkpoint
+        id: recovery_checkpoint
+        if: ${{ always() && !inputs.smoke_test_only && steps.package_release.outcome != 'skipped' && (inputs.resume_notarization_run_id == '' || steps.recovery_verified.outcome == 'success') && hashFiles('source/dist/macos-notarization-recovery/manifest.json') != '' }}
+        working-directory: source
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          checkpoint=dist/macos-notarization-recovery
+          python3 scripts/lib/mac-notarization-recovery.py verify "$checkpoint" \
+            "$(git rev-parse HEAD)" "$(node -p "require('./package.json').version")" >/dev/null
+          if [[ ! -f "$checkpoint/sparkle-tools.zip" ]]; then
+            tool=""
+            # Prefer the producer host's artifact, matching make_appcast.sh.
+            # Follow SwiftPM's build/cache links when collecting the full tool bundle.
+            for build_root in "apps/macos/.build/$(uname -m)" apps/macos/.build; do
+              if [[ -d "$build_root" ]]; then
+                tool="$(find -L "$build_root" -type f -path '*/artifacts/sparkle/Sparkle/bin/generate_appcast' -print -quit)"
+                [[ -z "$tool" ]] || break
+              fi
+            done
+            [[ -n "$tool" ]] || { echo "Missing producer Sparkle tools for recovery." >&2; exit 1; }
+            ditto -c -k --sequesterRsrc --keepParent "$(dirname "$(dirname "$tool")")" "$checkpoint/sparkle-tools.zip"
+          fi
+          node <<'NODE'
+          const fs = require('node:fs');
+          const { execFileSync } = require('node:child_process');
+          const data = { releaseTag: process.env.RELEASE_TAG,
+            sourceSha: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+            producerRunId: Number(process.env.GITHUB_RUN_ID), producerRunAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+            producerWorkflowSha: process.env.GITHUB_SHA, preflightOnly: true, smokeTestOnly: false };
+          fs.writeFileSync('dist/macos-notarization-recovery/workflow-release.json', `${JSON.stringify(data, null, 2)}\n`);
+          NODE
+          python3 scripts/lib/mac-notarization-recovery.py seal "$checkpoint"
+
+      - name: Upload notarization recovery checkpoint
+        if: ${{ always() && steps.recovery_checkpoint.outcome == 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-notarization-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: source/dist/macos-notarization-recovery
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Restore checkpointed Sparkle tools
+        if: ${{ inputs.resume_notarization_run_id != '' }}
+        working-directory: source
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import posixpath, stat, zipfile
+          with zipfile.ZipFile('dist/macos-notarization-recovery/sparkle-tools.zip') as archive:
+              for member in archive.infolist():
+                  name = member.filename
+                  if name.startswith('/') or '..' in name.split('/') or not name.startswith(('Sparkle/', '__MACOSX/')):
+                      raise ValueError('Unexpected Sparkle archive path')
+                  if stat.S_ISLNK(member.external_attr >> 16):
+                      target = archive.read(member).decode()
+                      resolved = posixpath.normpath(posixpath.join(posixpath.dirname(name), target))
+                      if target.startswith('/') or not resolved.startswith('Sparkle/'):
+                          raise ValueError('Sparkle archive symlink escapes root')
+          PY
+          ditto -x -k dist/macos-notarization-recovery/sparkle-tools.zip "$RUNNER_TEMP/recovery-sparkle"
+          tool="$RUNNER_TEMP/recovery-sparkle/Sparkle/bin/generate_appcast"
+          [[ -x "$tool" ]] || { echo "Recovered Sparkle generator is missing." >&2; exit 1; }
+          echo "SPARKLE_GENERATE_APPCAST=$tool" >> "$GITHUB_ENV"
 
       - name: Verify packaged OpenClaw signing identity
         if: ${{ !inputs.smoke_test_only }}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,38 @@ The macOS publish workflow builds from public `openclaw/openclaw` tags and uses
 the public repo's packaging scripts. Real publish runs promote previously
 prepared artifacts rather than rebuilding during the final upload step.
 
+### Resume a failed macOS notarization
+
+Signed preflights retain a `macos-notarization-<tag>-<run-id>-<attempt>` Actions
+artifact when the packaging script produces a valid recovery checkpoint. It
+contains the signed app, symbols, available DMG, Apple submission records, and
+the producer's Sparkle tools. Private signing keys are never included. Retention
+is 30 days; keep these payloads in Actions rather than the evidence ledger.
+
+Dispatch another signed preflight from `main`, using the checkpoint's exact
+public source commit and failed run attempt:
+
+```bash
+gh workflow run openclaw-macos-publish.yml --repo openclaw/releases --ref main \
+  -f tag=vYYYY.M.PATCH -f source_ref=<checkpoint-source-sha> \
+  -f preflight_only=true -f smoke_test_only=false \
+  -f resume_notarization_run_id=<failed-run-id> \
+  -f resume_notarization_run_attempt=<failed-run-attempt> \
+  -f public_release_branch=release/YYYY.M.PATCH
+```
+
+Recovery still requires `mac-release` approval. It verifies the producer,
+release/source binding, checkpoint hashes and signing identity, then resumes
+Apple submissions without rebuilding the app. An existing signed DMG is reused;
+if the failure preceded DMG creation, packaging creates and signs it after the
+app is notarized. The original Sparkle tools generate the final appcast.
+
+Use the successful recovery run as `preflight_run_id` for ordinary promotion,
+together with the successful validation run for the same source. Recovery does
+not replace validation or allow direct promotion from a failed run. Older source
+commits without the recovery interface, expired/missing checkpoints, and changed
+source commits fail explicitly; recovery never falls back to rebuilding.
+
 The scripts use only Node.js built-ins and require no dependency installation or
 build step. Run local checks with Node.js 24 and Python 3:
 

--- a/tests/test_macos_workflows.py
+++ b/tests/test_macos_workflows.py
@@ -21,6 +21,103 @@ def step_script(source, name):
 
 
 class MacOSWorkflowTests(unittest.TestCase):
+    def test_notarization_recovery_requires_main_signed_preflight_and_exact_attempt(self):
+        script = step_script(workflow('openclaw-macos-publish.yml'), 'Validate notarization recovery inputs')
+        valid = dict(RESUME_RUN_ID='123', RESUME_RUN_ATTEMPT='2', PREFLIGHT_ONLY='true',
+                     SMOKE_TEST_ONLY='false', WORKFLOW_REF='refs/heads/main')
+        for changes, accepted in [({}, True), ({'RESUME_RUN_ID': ''}, False),
+                                  ({'RESUME_RUN_ATTEMPT': ''}, False),
+                                  ({'RESUME_RUN_ATTEMPT': '0'}, False),
+                                  ({'RESUME_RUN_ID': '../123'}, False),
+                                  ({'PREFLIGHT_ONLY': 'false'}, False),
+                                  ({'SMOKE_TEST_ONLY': 'true'}, False),
+                                  ({'WORKFLOW_REF': 'refs/heads/feature'}, False),
+                                  ({'RESUME_RUN_ID': '', 'RESUME_RUN_ATTEMPT': ''}, True)]:
+            with self.subTest(changes=changes):
+                result = subprocess.run(['bash', '-c', script], env=dict(os.environ, **(valid | changes)),
+                                        capture_output=True, text=True)
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def test_recovery_rejects_wrong_workflow_attempt_or_successful_producer(self):
+        script = step_script(workflow('openclaw-macos-publish.yml'), 'Verify notarization checkpoint producer')
+        producer = dict(id=123, run_attempt=2, path='.github/workflows/openclaw-macos-publish.yml',
+                        head_branch='main', head_sha='a' * 40, event='workflow_dispatch',
+                        status='completed', conclusion='failure', repository={'full_name': 'openclaw/releases'})
+        for changes, accepted in [({}, True), ({'conclusion': 'cancelled'}, True),
+                                  ({'conclusion': 'success'}, False), ({'run_attempt': 1}, False),
+                                  ({'head_branch': 'feature'}, False), ({'path': 'untrusted.yml'}, False),
+                                  ({'repository': {'full_name': 'other/releases'}}, False),
+                                  ({'status': 'in_progress'}, False), ({'id': 456}, False),
+                                  ({'event': 'pull_request'}, False)]:
+            with self.subTest(changes=changes), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                gh = root / 'gh'
+                gh.write_text('#!/usr/bin/env python3\nimport os\nprint(os.environ["PRODUCER"])\n')
+                gh.chmod(0o755)
+                env = dict(os.environ, PATH=f'{root}:{os.environ["PATH"]}', RUNNER_TEMP=td,
+                           GITHUB_REPOSITORY='openclaw/releases', RESUME_RUN_ID='123',
+                           RESUME_RUN_ATTEMPT='2', PRODUCER=json.dumps(producer | changes))
+                result = subprocess.run(['bash', '-c', script], env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def test_recovery_calls_resume_without_reentering_build_steps(self):
+        publish = workflow('openclaw-macos-publish.yml')
+        script = step_script(publish, 'Build, sign, notarize, and package macOS release')
+        for run_id, expected in [('', []), ('123', ['--resume-notarization'])]:
+            with self.subTest(run_id=run_id), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / 'scripts').mkdir()
+                package = root / 'scripts/package-mac-dist.sh'
+                package.write_text('#!/usr/bin/env python3\nimport json,sys\nprint(json.dumps(sys.argv[1:]))\n')
+                package.chmod(0o755)
+                result = subprocess.run(['bash', '-c', script], cwd=root,
+                                        env=dict(os.environ, RESUME_RUN_ID=run_id), capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(json.loads(result.stdout), expected)
+        # Job scheduling is itself the contract: a resume must never install or compile.
+        for name in ['Checkout submodules (retry)', 'Setup pnpm', 'Install dependencies',
+                     'Cache SwiftPM', 'Release packaging guards', 'Build',
+                     'Build Control UI if missing', 'Validate release tag and package metadata', 'Verify release contents']:
+            step = publish.split(f'      - name: {name}\n', 1)[1].split('\n      - name:', 1)[0]
+            self.assertIn("if: ${{ inputs.resume_notarization_run_id == '' }}", step)
+        self.assertIn('environment: mac-release', publish.split('  build_sign_and_package:', 1)[1])
+
+    def test_checkpoint_binding_fails_before_packager_for_wrong_release_or_source(self):
+        script = step_script(workflow('openclaw-macos-publish.yml'), 'Verify notarization checkpoint release binding')
+        source_sha = 'b' * 40
+        producer = dict(id=123, run_attempt=2, head_sha='a' * 40)
+        envelope = dict(releaseTag='v2026.8.2', sourceSha=source_sha, producerRunId=123,
+                        producerRunAttempt=2, producerWorkflowSha='a' * 40,
+                        preflightOnly=True, smokeTestOnly=False)
+        manifest = dict(schemaVersion=1, sourceSha=source_sha, version='2026.8.2',
+                        skipDmg=False, skipDsym=False)
+        cases = [({}, {}, True), ({'releaseTag': 'v2026.8.1'}, {}, False),
+                 ({'producerRunAttempt': 1}, {}, False), ({'producerWorkflowSha': 'c' * 40}, {}, False),
+                 ({'smokeTestOnly': True}, {}, False), ({}, {'sourceSha': 'c' * 40}, False),
+                 ({}, {'version': '2026.8.1'}, False), ({}, {'skipDmg': True}, False)]
+        for envelope_changes, manifest_changes, accepted in cases:
+            with self.subTest(envelope=envelope_changes, manifest=manifest_changes), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / 'scripts/lib').mkdir(parents=True)
+                (root / 'scripts/package-mac-dist.sh').write_text('# --resume-notarization\n')
+                (root / 'scripts/lib/mac-notarization-recovery.py').write_text('import pathlib\npathlib.Path("verified").touch()\n')
+                (root / 'package.json').write_text(json.dumps({'version': '2026.8.2'}))
+                checkpoint = root / 'dist/macos-notarization-recovery'
+                checkpoint.mkdir(parents=True)
+                (checkpoint / 'workflow-release.json').write_text(json.dumps(envelope | envelope_changes))
+                (checkpoint / 'manifest.json').write_text(json.dumps(manifest | manifest_changes))
+                (root / 'notarization-producer.json').write_text(json.dumps(producer))
+                git = root / 'git'
+                git.write_text(f'#!/bin/sh\nif [ "$1" = rev-parse ]; then echo {source_sha}; fi\n')
+                git.chmod(0o755)
+                result = subprocess.run(['bash', '-c', script], cwd=root,
+                                        env=dict(os.environ, PATH=f'{root}:{os.environ["PATH"]}',
+                                                 RUNNER_TEMP=td, RELEASE_TAG='v2026.8.2',
+                                                 PUBLIC_RELEASE_BRANCH='release/2026.8.2'),
+                                        capture_output=True, text=True)
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+                self.assertEqual((root / 'verified').exists(), accepted)
+
     def test_complete_isolated_suite_and_failure_propagation(self):
         script = step_script(workflow('openclaw-macos-validate.yml'), 'Swift test')
         # A failed build, failed profile, or timed-out profile must never upload


### PR DESCRIPTION
A failed Apple notarization currently discards the runner's signed build, so another preflight repeats compilation and signing. Preserve a verified, attempt-specific checkpoint and add a signed-preflight recovery mode that resumes the same Apple submissions without rebuilding the app.

Recovery retains the `mac-release` environment approval and accepts only a completed failed or cancelled run of this workflow from `main`. Before calling the public packaging helper, it checks the exact producer attempt, release tag, source commit, package version, packaging flags, and checkpoint hashes. The public helper owns signed-app validation and submission continuity. Successful recovery emits the existing preflight artifacts; ordinary publication still requires a successful preflight and matching Swift validation. Existing signed DMGs are reused, while a DMG not yet created is packaged after the app finishes notarization.

The checkpoint also preserves the producer's Sparkle tool bundle, including executable permissions and support libraries, so a fresh runner can generate the final appcast without resolving or rebuilding Swift dependencies. Invalid checkpoints are rejected before resealing; older source commits without the recovery interface fail explicitly. Artifacts stay in Actions with 30-day retention.

Validation: six workflow tests pass, including rejected producer/release bindings and the no-build recovery dispatch. An integration check with the actual public checkpoint helper exercised a symlinked Swift cache, Sparkle executable/support-file round trip, and changed-artifact rejection before resealing. The new recovery cases fail against the old workflow. YAML parsing and `git diff --check` pass; isolated Codex review found no actionable findings at its default P0 threshold.

Depends on the companion public packaging helper change before the first recovery dispatch. The active 2026.8.2 release attempt is unchanged. Workflow additions implement the cross-run artifact and approval boundary; no application runtime code changes.
