### PR TITLE
fix(macos): reject stale appcasts before retention and promotion

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -169,6 +169,12 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Checkout release verification tools
+        uses: actions/checkout@v7
+        with:
+          path: release-tools
+          persist-credentials: false
+
       - name: Clone selected public source
         env:
           RELEASE_TAG: ${{ inputs.tag }}
@@ -698,6 +704,9 @@ jobs:
       - name: Resolve appcast path
         id: appcast_path
         if: ${{ !inputs.smoke_test_only && steps.release_channel.outputs.is_beta != 'true' }}
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          ZIP_PATH: ${{ steps.packaged_files.outputs.zip }}
         run: |
           set -euo pipefail
           APPCAST_PATH="source/appcast.xml"
@@ -705,6 +714,8 @@ jobs:
             echo "Stable appcast artifact not found." >&2
             exit 1
           fi
+          python3 release-tools/scripts/verify-macos-appcast.py "$APPCAST_PATH" "$ZIP_PATH" \
+            "$RELEASE_TAG" "$OPENCLAW_REPOSITORY"
           echo "path=$APPCAST_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Resolve packaged version
@@ -795,6 +806,12 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Checkout release verification tools
+        uses: actions/checkout@v7
+        with:
+          path: release-tools
+          persist-credentials: false
+
       - name: Ensure matching public GitHub release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -978,6 +995,9 @@ jobs:
       - name: Resolve appcast path
         id: appcast_path
         if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          ZIP_PATH: ${{ steps.packaged_files.outputs.zip }}
         run: |
           set -euo pipefail
           APPCAST_PATH="$(find promoted-appcast -type f -name 'appcast.xml' -print | sort | tail -n 1)"
@@ -985,6 +1005,8 @@ jobs:
             echo "Stable appcast artifact not found." >&2
             exit 1
           fi
+          python3 release-tools/scripts/verify-macos-appcast.py "$APPCAST_PATH" "$ZIP_PATH" \
+            "$RELEASE_TAG" "$OPENCLAW_REPOSITORY"
           echo "path=$APPCAST_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Resolve packaged version

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ maintenance, and durable release evidence separate from the product source repo.
 
 The macOS publish workflow builds from public `openclaw/openclaw` tags and uses
 the public repo's packaging scripts. Real publish runs promote previously
-prepared artifacts rather than rebuilding during the final upload step.
+prepared artifacts rather than rebuilding during the final upload step. Stable
+appcasts must match the packaged app's version and build, release ZIP URL and
+byte length, and contain a Sparkle signature before retention and promotion.
+An existing seed feed alone is not valid release output.
 
 ### Resume a failed macOS notarization
 

--- a/scripts/verify-macos-appcast.py
+++ b/scripts/verify-macos-appcast.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Bind a retained or promoted Sparkle entry to its exact packaged app."""
+import argparse
+from pathlib import Path
+import plistlib
+import xml.etree.ElementTree as ET
+import zipfile
+
+SPARKLE = '{http://www.andymatuschak.org/xml-namespaces/sparkle}'
+
+
+def verify(appcast, package, tag, repository):
+    version = tag.removeprefix('v')
+    if package.name != f'OpenClaw-{version}.zip':
+        raise ValueError('Packaged ZIP filename does not match the release tag')
+    with zipfile.ZipFile(package) as archive:
+        plist_path = 'OpenClaw.app/Contents/Info.plist'
+        if archive.namelist().count(plist_path) != 1:
+            raise ValueError('Packaged ZIP must contain one OpenClaw Info.plist')
+        info = plistlib.loads(archive.read(plist_path))
+    if info.get('CFBundleShortVersionString') != version:
+        raise ValueError('Packaged app version does not match the release tag')
+    build = info.get('CFBundleVersion', '')
+    if not isinstance(build, str) or not build.isdecimal():
+        raise ValueError('Packaged app build must be numeric')
+    items = [item for item in ET.parse(appcast).findall('./channel/item')
+             if item.findtext(f'{SPARKLE}shortVersionString') == version]
+    if len(items) != 1:
+        raise ValueError(f'Appcast must contain exactly one release {version}')
+    item = items[0]
+    if item.findtext(f'{SPARKLE}version') != build:
+        raise ValueError('Appcast build does not match the packaged app')
+    enclosures = item.findall('enclosure')
+    if len(enclosures) != 1:
+        raise ValueError('Appcast release must contain exactly one enclosure')
+    enclosure = enclosures[0]
+    expected_url = f'https://github.com/{repository}/releases/download/{tag}/{package.name}'
+    if enclosure.get('url') != expected_url:
+        raise ValueError('Appcast download URL does not match the release ZIP')
+    if enclosure.get('length') != str(package.stat().st_size):
+        raise ValueError('Appcast download length does not match the release ZIP')
+    # Signing belongs to the producer. This boundary verifies identity and
+    # signature presence; it does not claim cryptographic verification.
+    if not enclosure.get(f'{SPARKLE}edSignature', '').strip():
+        raise ValueError('Appcast release is missing its Ed25519 signature')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('appcast', type=Path)
+    parser.add_argument('package', type=Path)
+    parser.add_argument('tag')
+    parser.add_argument('repository')
+    args = parser.parse_args()
+    try:
+        verify(args.appcast, args.package, args.tag, args.repository)
+    except (ValueError, OSError, ET.ParseError, zipfile.BadZipFile) as error:
+        parser.exit(1, f'Invalid macOS appcast: {error}\n')
+    print(f'Appcast matches {args.tag} and {args.package.name}')

--- a/tests/test_macos_workflows.py
+++ b/tests/test_macos_workflows.py
@@ -1,11 +1,13 @@
 """Exercise macOS release workflow failure propagation without Apple services."""
 import json
 import os
+import plistlib
 from pathlib import Path
 import re
 import subprocess
 import tempfile
 import unittest
+import zipfile
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -21,6 +23,40 @@ def step_script(source, name):
 
 
 class MacOSWorkflowTests(unittest.TestCase):
+    def test_appcast_retention_and_promotion_reject_stale_or_mismatched_artifacts(self):
+        build, promote = workflow('openclaw-macos-publish.yml').split('  promote_release_artifacts:', 1)
+        cases = [({}, True), ({'version': '2026.8.1'}, False),
+                 ({'build': '202608010'}, False), ({'url_tag': 'v2026.8.1'}, False),
+                 ({'length': '1'}, False), ({'signature': ''}, False),
+                 ({'bundle_version': '2026.8.1'}, False)]
+        for stage, source, directory in [('retention', build, 'source'), ('promotion', promote, 'promoted-appcast')]:
+            script = step_script(source, 'Resolve appcast path')
+            for changes, accepted in cases:
+                with self.subTest(stage=stage, changes=changes), tempfile.TemporaryDirectory() as td:
+                    root = Path(td)
+                    (root / directory).mkdir()
+                    (root / 'release-tools').symlink_to(ROOT, target_is_directory=True)
+                    package = root / 'OpenClaw-2026.8.2.zip'
+                    values = dict(version='2026.8.2', build='202608020', url_tag='v2026.8.2',
+                                  signature='fixture-signature', bundle_version='2026.8.2') | changes
+                    with zipfile.ZipFile(package, 'w') as archive:
+                        archive.writestr('OpenClaw.app/Contents/Info.plist', plistlib.dumps({
+                            'CFBundleShortVersionString': values['bundle_version'], 'CFBundleVersion': '202608020'}))
+                    length = values.get('length', str(package.stat().st_size))
+                    (root / directory / 'appcast.xml').write_text(f'''<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item>
+                        <sparkle:shortVersionString>{values['version']}</sparkle:shortVersionString>
+                        <sparkle:version>{values['build']}</sparkle:version>
+                        <enclosure url="https://github.com/openclaw/openclaw/releases/download/{values['url_tag']}/{package.name}"
+                          length="{length}" sparkle:edSignature="{values['signature']}"/>
+                        </item></channel></rss>''')
+                    result = subprocess.run(['bash', '-c', script], cwd=root,
+                                            env=dict(os.environ, RELEASE_TAG='v2026.8.2',
+                                                     OPENCLAW_REPOSITORY='openclaw/openclaw', ZIP_PATH=str(package),
+                                                     GITHUB_OUTPUT=str(root / 'output')),
+                                            capture_output=True, text=True)
+                    self.assertEqual(result.returncode == 0, accepted, result.stderr)
+                    self.assertEqual((root / 'output').exists(), accepted)
+
     def test_notarization_recovery_requires_main_signed_preflight_and_exact_attempt(self):
         script = step_script(workflow('openclaw-macos-publish.yml'), 'Validate notarization recovery inputs')
         valid = dict(RESUME_RUN_ID='123', RESUME_RUN_ATTEMPT='2', PREFLIGHT_ONLY='true',


### PR DESCRIPTION
## Summary

A macOS preflight could retain the seeded appcast after generation failed, and promotion accepted that stale feed because it checked only that `appcast.xml` existed. This adds one shared validator at both retention and promotion, binding the selected release entry to the actual packaged ZIP before either upload boundary.

The validator reads the ZIP's `Info.plist` and requires the release version and build, exact GitHub release download URL, ZIP byte length, and a nonempty Sparkle signature. It checks signature presence, not cryptographic validity; signing remains the producer's responsibility. Both jobs use verification tools checked out from the current workflow revision. Beta and smoke-test appcast gates remain unchanged.

## Validation

- All seven workflow regression tests passed. The new table executes both real workflow step scripts and proves stale versions, mismatched builds/download tags/lengths, missing signatures, and mismatched bundle versions fail. Each malformed case was accepted by both pre-fix boundaries.
- The validator passed against the actual corrected 2026.8.2 appcast and original signed release ZIP, without rebuilding or modifying either artifact.
- Codex autoreview completed with no actionable P0 findings; `git diff --check` passed.

Production tooling adds 81 lines for the shared artifact identity boundary; tests add 36, and documentation adds three net lines. No signing, notarization, environment approval, or publication authority changes.
