### PR TITLE
perf(macos): remove duplicate release preflight build

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -360,23 +360,13 @@ jobs:
           pnpm check:changelog-attributions
           pnpm check:host-env-policy:swift
 
-      - name: Build
+      - name: Build and verify release contents
         if: ${{ inputs.resume_notarization_run_id == '' }}
         working-directory: source
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
-
-      - name: Build Control UI if missing
-        if: ${{ inputs.resume_notarization_run_id == '' }}
-        working-directory: source
-        run: |
-          set -euo pipefail
-          if [[ -f dist/control-ui/index.html ]]; then
-            echo "Control UI was already built by pnpm build; skipping."
-            exit 0
-          fi
-          node scripts/ui.js build
+        # release:check owns the package build, including Control UI assets.
+        run: pnpm release:check
 
       - name: Validate release tag and package metadata
         if: ${{ inputs.resume_notarization_run_id == '' }}
@@ -414,13 +404,6 @@ jobs:
             }
           '
           echo "::warning::Allowing late mac-only recovery for ${RELEASE_TAG}; published npm metadata for openclaw@${package_version} is present."
-
-      - name: Verify release contents
-        if: ${{ inputs.resume_notarization_run_id == '' }}
-        working-directory: source
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096
-        run: pnpm release:check
 
       - name: Capture release provenance
         id: release_provenance

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ the public repo's packaging scripts. Real publish runs promote previously
 prepared artifacts rather than rebuilding during the final upload step. Stable
 appcasts must match the packaged app's version and build, release ZIP URL and
 byte length, and contain a Sparkle signature before retention and promotion.
-An existing seed feed alone is not valid release output.
+An existing seed feed alone is not valid release output. The preflight uses
+`pnpm release:check` to build and validate package contents once before metadata
+validation; native app packaging retains its own matching runtime build.
 
 ### Resume a failed macOS notarization
 

--- a/tests/test_macos_workflows.py
+++ b/tests/test_macos_workflows.py
@@ -23,6 +23,56 @@ def step_script(source, name):
 
 
 class MacOSWorkflowTests(unittest.TestCase):
+    def test_release_build_is_owned_by_validation_before_metadata_and_skipped_on_resume(self):
+        publish = workflow('openclaw-macos-publish.yml')
+        phase = publish.split('      - name: Release packaging guards\n', 1)[1].split('      - name: Capture release provenance\n', 1)[0]
+        steps = phase.split('      - name: ')[1:]
+        for resume, fail, expected in [('', False, ['release:check', 'release:openclaw:npm:check']),
+                                        ('', True, ['release:check']), ('123', False, [])]:
+            with self.subTest(resume=resume, fail=fail), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                pnpm = root / 'pnpm'
+                pnpm.write_text('''#!/usr/bin/env python3
+import json, os, pathlib, sys
+command = sys.argv[1]
+with open('calls', 'a') as calls:
+    calls.write(json.dumps({'command': command, 'heap': os.environ.get('NODE_OPTIONS')}) + '\\n')
+if command in ('build', 'release:check'):
+    if command == 'release:check' and os.environ['FAIL_BUILD'] == '1':
+        sys.exit(23)
+    pathlib.Path('dist/control-ui').mkdir(parents=True, exist_ok=True)
+    pathlib.Path('dist/control-ui/index.html').write_text('built')
+if command == 'release:openclaw:npm:check' and not pathlib.Path('dist/control-ui/index.html').exists():
+    sys.exit(24)
+''')
+                pnpm.chmod(0o755)
+                git = root / 'git'
+                git.write_text('#!/bin/sh\nif [ "$1" = rev-parse ]; then printf "%040d\\n" 1; fi\n')
+                git.chmod(0o755)
+                result_code = 0
+                for step in steps:
+                    self.assertIn("if: ${{ inputs.resume_notarization_run_id == '' }}", step)
+                    if resume:
+                        continue
+                    run = step.split('        run: ', 1)[1]
+                    script = ('\n'.join(line[10:] for line in run.splitlines()[1:])
+                              if run.startswith('|\n') else run.splitlines()[0])
+                    heap = re.search(r'NODE_OPTIONS: (.+)', step)
+                    result = subprocess.run(['bash', '-c', script], cwd=root, capture_output=True, text=True,
+                                            env=dict(os.environ, PATH=f'{root}:{os.environ["PATH"]}',
+                                                     NODE_OPTIONS=heap.group(1) if heap else '',
+                                                     FAIL_BUILD='1' if fail else '0', RELEASE_TAG='v2026.8.2',
+                                                     PUBLIC_RELEASE_BRANCH='release/2026.8.2', RUNNER_TEMP=td,
+                                                     ALLOW_LATE_CALVER_RECOVERY='false'))
+                    result_code = result.returncode
+                    if result_code:
+                        break
+                calls = [json.loads(line) for line in (root / 'calls').read_text().splitlines()] if (root / 'calls').exists() else []
+                self.assertEqual([call['command'] for call in calls], expected)
+                self.assertEqual(result_code, 23 if fail else 0)
+                if calls:
+                    self.assertEqual(calls[0]['heap'], '--max-old-space-size=8192')
+
     def test_appcast_retention_and_promotion_reject_stale_or_mismatched_artifacts(self):
         build, promote = workflow('openclaw-macos-publish.yml').split('  promote_release_artifacts:', 1)
         cases = [({}, True), ({'version': '2026.8.1'}, False),
@@ -112,8 +162,8 @@ class MacOSWorkflowTests(unittest.TestCase):
                 self.assertEqual(json.loads(result.stdout), expected)
         # Job scheduling is itself the contract: a resume must never install or compile.
         for name in ['Checkout submodules (retry)', 'Setup pnpm', 'Install dependencies',
-                     'Cache SwiftPM', 'Release packaging guards', 'Build',
-                     'Build Control UI if missing', 'Validate release tag and package metadata', 'Verify release contents']:
+                     'Cache SwiftPM', 'Release packaging guards', 'Build and verify release contents',
+                     'Validate release tag and package metadata']:
             step = publish.split(f'      - name: {name}\n', 1)[1].split('\n      - name:', 1)[0]
             self.assertIn("if: ${{ inputs.resume_notarization_run_id == '' }}", step)
         self.assertIn('environment: mac-release', publish.split('  build_sign_and_package:', 1)[1])


### PR DESCRIPTION
The macOS preflight ran `pnpm build`, then `pnpm release:check` immediately built the package again. Run the existing canonical `release:check` once in the first build position, before metadata validation consumes its outputs. Remove the separate build and redundant Control UI fallback, preserving the existing 8GB build heap.

All release-content and metadata checks remain in place. Notarization recovery skips the entire build phase as before, and native app packaging retains its own matching runtime build and provenance checks.

Validation: all eight workflow tests pass. The regression executes the workflow shell steps and proves one package-build owner before metadata checks, stops on validation failure, and runs no builds during recovery. It failed against the previous workflow because both build owners ran and metadata validation preceded release-content validation. Codex autoreview found no actionable P0 issues; `git diff --check` passed. Tooling removes 17 net lines; tests add 50 and documentation adds two.
