### PR TITLE
fix(macos): prepare Mermaid assets before validate and publish builds

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -235,6 +235,19 @@ jobs:
           CI: "true"
         run: pnpm install --frozen-lockfile
 
+      - name: Prepare Apple Mermaid assets
+        if: ${{ inputs.resume_notarization_run_id == '' }}
+        working-directory: source
+        run: |
+          set -euo pipefail
+          # Mirrors product CI: OpenClawChatUI bundles generated Mermaid resources
+          # (scripts/prepare-apple-mermaid.mjs) that SwiftPM copies at build time.
+          if [[ -f scripts/prepare-apple-mermaid.mjs ]]; then
+            node scripts/prepare-apple-mermaid.mjs
+          else
+            echo "Source predates bundled Mermaid assets; nothing to prepare."
+          fi
+
       - name: Select release toolchain
         run: |
           sudo xcode-select -s /Applications/Xcode_26.6.app

--- a/.github/workflows/openclaw-macos-validate.yml
+++ b/.github/workflows/openclaw-macos-validate.yml
@@ -82,10 +82,36 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: source/package.json
+          run_install: false
+
       - name: Setup Node.js for native test isolation
         uses: actions/setup-node@v7
         with:
           node-version: "24.20.0"
+          cache: pnpm
+          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: source
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare Apple Mermaid assets
+        working-directory: source
+        run: |
+          set -euo pipefail
+          # Mirrors product CI: OpenClawChatUI bundles generated Mermaid resources
+          # (scripts/prepare-apple-mermaid.mjs) that SwiftPM copies at build time.
+          if [[ -f scripts/prepare-apple-mermaid.mjs ]]; then
+            node scripts/prepare-apple-mermaid.mjs
+          else
+            echo "Source predates bundled Mermaid assets; nothing to prepare."
+          fi
 
       - name: Cache SwiftPM
         uses: actions/cache@v6


### PR DESCRIPTION
## What Problem This Solves

`openclaw-macos-validate` (run 33775832773, tag v2026.9.1) failed in `swift build` with `couldn't build .../OpenClawKit_OpenClawChatUI.bundle/Mermaid because of missing inputs: .../OpenClawChatUI/Resources/Mermaid`. The publish workflow builds the same package and would fail the same way.

## Why This Change Was Made

openclaw/openclaw#135470 bundles generated Mermaid resources into OpenClawChatUI; `scripts/prepare-apple-mermaid.mjs` produces them and product CI runs it before every Apple build. These workflows never did. Both now run the same guarded step (no-op when the source predates the script) after dependency install; the validate workflow gains the pnpm setup and install the script needs.

## User Impact

macOS release validation and publication work again for 2026.9.1 and later sources that bundle Mermaid.

## Evidence

- Failing run: https://github.com/openclaw/releases/actions/runs/33775832773
- Product CI reference: openclaw/openclaw `.github/workflows/ci.yml` "Prepare Apple Mermaid assets" step.
- `git diff --check` clean; validate workflow re-dispatched from this branch for v2026.9.1 (run linked below once complete).
