### PR TITLE
docs(release): include macOS in release authorization

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -162,8 +162,8 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.reuse_preflight != 'true' }}
     runs-on: macos-26
-    # Match npm-release: signing and notarization stay behind the mac-release
-    # environment's required release-manager approval gate.
+    # Release authorization covers signing and notarization; mac-release owns
+    # the secrets and main-only deployment policy without a second approval.
     environment: mac-release
     permissions:
       actions: read

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gh workflow run openclaw-macos-publish.yml --repo openclaw/releases --ref main \
   -f public_release_branch=release/YYYY.M.PATCH
 ```
 
-Recovery still requires `mac-release` approval. It verifies the producer,
+Recovery uses the same release authorization and `mac-release` environment. It verifies the producer,
 release/source binding, checkpoint hashes and signing identity, then resumes
 Apple submissions without rebuilding the app. An existing signed DMG is reused;
 if the failure preceded DMG creation, packaging creates and signs it after the
@@ -85,19 +85,23 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
 
 ## Release Approval
 
-The `mac-release` environment is the macOS equivalent of the public repo's
-`npm-release` environment:
+An explicit request to release OpenClaw authorizes the macOS release through
+validation, signing, notarization, and promotion. Do not ask for a separate
+macOS approval after the release has already been authorized.
 
 - real macOS preflight and promotion jobs must use `mac-release`
-- `mac-release` requires approval from `openclaw-release-managers`
-- real publish runs must be dispatched from this repo's `main` branch
-- read-only maintainers can inspect the run; dispatch and approval stay with
-  the configured release-manager reviewers, matching npm release policy
+- `mac-release` has no required reviewers or wait timer; the authorized
+  operator dispatches the release workflows
+- the environment permits deployments only from this repo's `main` branch
+- successful validation and signed preflight artifacts for the exact tag and
+  source remain required before promotion
+- read-only maintainers can inspect runs; repository permissions control who
+  can dispatch them
 
-Keep the environment's required-reviewer rule, enabled self-review prevention,
-main-branch policy, and disabled administrator bypass aligned with the macOS
-release policy. Do not move signing or promotion secrets into repository-level
-secrets.
+Keep signing and promotion secrets in `mac-release`, with its main-only branch
+policy intact. Do not approve a job on someone else's behalf or use an alternate
+signing path to bypass an enforced rule. Organization owners manage the
+environment policy; changes to that policy require explicit owner direction.
 
 ## Release Evidence
 


### PR DESCRIPTION
An organization owner explicitly directed that a request to release OpenClaw includes macOS publication without a second approval. Document that policy for normal release and notarization recovery, and align the signing-job comment. The matching `mac-release` environment update removes required reviewers and its inactive self-review setting while preserving the existing main-only branch restriction, environment-scoped secrets, and all source, validation, signing, notarization, and artifact-promotion checks. No workflow execution logic changes.

Validation: all eight existing macOS workflow tests passed with Node 24 and Python 3.12; executable workflow content is identical after excluding comments; `git diff --check` passed; independent managed Codex review found no actionable P0–P2 issues. Live authority checks confirmed the acting account is the requesting active organization administrator. The existing 2026.9.2 public and Swift validations passed; its signing preflight demonstrates the redundant approval pause. Environment application and exact-run continuation will be verified separately after this policy lands.
