### PR TITLE
feat(release): prepare signed mac artifacts before tagging

### DIFF
--- a/.github/workflows/openclaw-macos-publish.yml
+++ b/.github/workflows/openclaw-macos-publish.yml
@@ -7,6 +7,10 @@ on:
         description: Existing OpenClaw release tag to package (for example v2026.3.22 or v2026.3.22-beta.1)
         required: true
         type: string
+      pretag_source_sha:
+        description: Exact signed stable release branch head for artifact-only preparation before tagging; leave empty for normal tagged releases
+        required: false
+        type: string
       source_ref:
         description: Optional public openclaw/openclaw source ref to build instead of the tag, for release-branch-only packaging fixes after npm/tag publication
         required: false
@@ -68,6 +72,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Forbid pretag artifact promotion
+        if: ${{ inputs.pretag_source_sha != '' && (!inputs.preflight_only || inputs.smoke_test_only || inputs.source_ref != '' || inputs.resume_notarization_run_id != '' || github.ref != 'refs/heads/main') }}
+        run: |
+          echo "Pretag source is only valid for fresh signed artifact-only preparation from main." >&2
+          exit 1
+
       - name: Validate notarization recovery inputs
         env:
           RESUME_RUN_ID: ${{ inputs.resume_notarization_run_id }}
@@ -175,7 +185,23 @@ jobs:
           path: release-tools
           persist-credentials: false
 
+      - name: Admit signed pretag source
+        if: ${{ inputs.pretag_source_sha != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRETAG_SOURCE_SHA: ${{ inputs.pretag_source_sha }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          WORKFLOW_REF: ${{ github.ref }}
+          PUBLIC_RELEASE_BRANCH: ${{ inputs.public_release_branch }}
+          PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
+          SMOKE_TEST_ONLY: ${{ inputs.smoke_test_only }}
+          RESUME_RUN_ID: ${{ inputs.resume_notarization_run_id }}
+        run: |
+          python3 release-tools/scripts/checkout-macos-pretag.py
+
       - name: Clone selected public source
+        if: ${{ inputs.pretag_source_sha == '' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           SOURCE_REF: ${{ inputs.source_ref }}

--- a/.github/workflows/openclaw-macos-validate.yml
+++ b/.github/workflows/openclaw-macos-validate.yml
@@ -7,6 +7,10 @@ on:
         description: Existing OpenClaw release tag to validate on macOS (for example v2026.3.22 or v2026.3.22-beta.1)
         required: true
         type: string
+      pretag_source_sha:
+        description: Exact signed stable release branch head for artifact-only preparation before tagging; leave empty for normal tagged releases
+        required: false
+        type: string
       source_ref:
         description: Optional public openclaw/openclaw source ref to validate instead of the tag, for release-branch-only packaging fixes after npm/tag publication
         required: false
@@ -37,7 +41,28 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout release verification tools
+        uses: actions/checkout@v7
+        with:
+          path: release-tools
+          persist-credentials: false
+
+      - name: Admit signed pretag source
+        if: ${{ inputs.pretag_source_sha != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRETAG_SOURCE_SHA: ${{ inputs.pretag_source_sha }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          WORKFLOW_REF: ${{ github.ref }}
+          PREFLIGHT_ONLY: "true"
+          SMOKE_TEST_ONLY: "false"
+        run: |
+          export PUBLIC_RELEASE_BRANCH="release/${RELEASE_TAG#v}"
+          python3 release-tools/scripts/checkout-macos-pretag.py
+
       - name: Clone selected public source
+        if: ${{ inputs.pretag_source_sha == '' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           SOURCE_REF: ${{ inputs.source_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+- Start signed macOS artifact preparation and Swift validation from an exact signed release candidate before tagging, while preserving final publication provenance.
+
 - Verify the complete release evidence directory after publication, reject concurrent changes to that directory, and share publication handling between both workflows. Thanks @vincentkoc.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,35 @@ An existing seed feed alone is not valid release output. The preflight uses
 `pnpm release:check` to build and validate package contents once before metadata
 validation; native app packaging retains its own matching runtime build.
 
+### Prepare signed macOS artifacts before tagging
+
+After freezing the final signed source commit on `release/YYYY.M.PATCH`, start
+signing/notarization and Swift validation concurrently from this repository's
+trusted `main`. Neither run creates a tag or publishes assets:
+
+```bash
+gh workflow run openclaw-macos-publish.yml --repo openclaw/releases --ref main \
+  -f tag=vYYYY.M.PATCH -f pretag_source_sha=<exact-signed-final-source-sha> \
+  -f preflight_only=true -f smoke_test_only=false \
+  -f public_release_branch=release/YYYY.M.PATCH
+gh workflow run openclaw-macos-validate.yml --repo openclaw/releases --ref main \
+  -f tag=vYYYY.M.PATCH -f pretag_source_sha=<exact-signed-final-source-sha>
+```
+
+Pretag preparation supports stable versions. It requires the exact canonical
+release branch head, valid GitHub commit signature verification, and matching
+package identity before checking out or executing public source. It rejects
+`source_ref`, smoke mode, notarization recovery, and publication. A tag created
+while the run queues must point at the same commit. Normal tagged recovery and
+promotion keep their existing provenance checks.
+
+The app embeds its real source SHA in signed metadata. A later CHANGELOG-only
+commit is therefore **not** equivalent for artifact promotion: finalize the
+changelog before starting, or rerun the producer to rebuild, sign, and notarize
+the new final source. Never relabel previously signed bytes. When the eventual
+tag selects the unchanged pretag SHA, use the successful preflight and validation
+run IDs in ordinary promotion after the public GitHub release exists.
+
 ### Resume a failed macOS notarization
 
 Signed preflights retain a `macos-notarization-<tag>-<run-id>-<attempt>` Actions

--- a/scripts/checkout-macos-pretag.py
+++ b/scripts/checkout-macos-pretag.py
@@ -1,0 +1,55 @@
+"""Admit an exact signed public release candidate before executing its source."""
+import json
+import os
+import re
+import subprocess
+
+
+def run(*args):
+    return subprocess.check_output(args, text=True).strip()
+
+
+def checkout():
+    sha = os.environ['PRETAG_SOURCE_SHA']
+    tag = os.environ['RELEASE_TAG']
+    branch = os.environ['PUBLIC_RELEASE_BRANCH']
+    if (os.environ['WORKFLOW_REF'] != 'refs/heads/main'
+            or os.environ['PREFLIGHT_ONLY'] != 'true'
+            or os.environ['SMOKE_TEST_ONLY'] != 'false'
+            or os.environ.get('SOURCE_REF', '')
+            or os.environ.get('RESUME_RUN_ID', '')):
+        raise ValueError('Pretag admission requires a fresh signed artifact-only preflight from main')
+    if not re.fullmatch(r'[0-9a-f]{40}', sha):
+        raise ValueError('Pretag source must be an exact full commit SHA')
+    if not re.fullmatch(r'v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*', tag):
+        raise ValueError('Pretag admission currently supports stable release versions only')
+    if branch != f'release/{tag[1:]}':
+        raise ValueError('Pretag source requires the canonical release branch for its version')
+
+    subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout',
+                    'https://github.com/openclaw/openclaw.git', 'source'], check=True)
+    def git(*args):
+        return run('git', '-C', 'source', *args)
+    if git('rev-parse', f'refs/remotes/origin/{branch}') != sha:
+        raise ValueError('Pretag source must equal the current canonical release branch head')
+    commit = json.loads(run('gh', 'api', f'repos/openclaw/openclaw/commits/{sha}'))
+    verification = commit.get('commit', {}).get('verification', {})
+    if (commit.get('sha') != sha or verification.get('verified') is not True
+            or verification.get('reason') != 'valid'):
+        raise ValueError('Pretag source requires valid GitHub commit signature verification')
+    package = json.loads(git('show', f'{sha}:package.json'))
+    if package.get('name') != 'openclaw' or package.get('version') != tag[1:]:
+        raise ValueError('Pretag source package identity does not match the requested release')
+    # A tag created while this run queued is fine only when it freezes these bytes.
+    existing = git('for-each-ref', '--format=%(refname)', f'refs/tags/{tag}')
+    if f'refs/tags/{tag}' in existing.splitlines():
+        if git('rev-parse', f'refs/tags/{tag}^{{commit}}') != sha:
+            raise ValueError('Existing release tag selects a different source commit')
+    git('checkout', '--detach', sha)
+    if git('rev-parse', 'HEAD') != sha:
+        raise ValueError('Checked-out source does not match the admitted commit')
+    print(f'Admitted signed pretag source {sha} from {branch}; publication remains disabled.')
+
+
+if __name__ == '__main__':
+    checkout()

--- a/tests/test_macos_pretag.py
+++ b/tests/test_macos_pretag.py
@@ -1,0 +1,89 @@
+"""Exercise pretag source admission with real Git and synthetic GitHub metadata."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+GIT = shutil.which('git')
+
+
+class PretagSourceTests(unittest.TestCase):
+    def test_admits_only_matching_signed_canonical_source_before_checkout(self):
+        cases = [({}, True), ({'signature': False}, False), ({'reason': 'unsigned'}, False),
+                 ({'api_sha': 'a' * 40}, False), ({'api_failure': True}, False),
+                 ({'version': '2026.9.2'}, False), ({'name': 'other'}, False),
+                 ({'tag_other': True}, False), ({'tag_same': True}, True),
+                 ({'branch_advanced': True}, False), ({'sha': 'a' * 40}, False),
+                 ({'sha': 'main'}, False), ({'workflow': 'refs/heads/feature'}, False),
+                 ({'preflight': 'false'}, False), ({'smoke': 'true'}, False),
+                 ({'source_ref': 'main'}, False), ({'resume': '123'}, False),
+                 ({'branch': 'main'}, False), ({'tag': 'v2026.9.3-beta.1'}, False)]
+        for changes, accepted in cases:
+            with self.subTest(changes=changes), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                repo = root / 'remote'
+                repo.mkdir()
+                def git(*args):
+                    return subprocess.check_output([GIT, '-C', str(repo), *args], text=True,
+                                                   stderr=subprocess.DEVNULL).strip()
+                git('init', '-b', 'release/2026.9.3')
+                git('config', 'user.name', 'Fixture')
+                git('config', 'user.email', 'fixture@example.invalid')
+                git('config', 'commit.gpgsign', 'false')
+                (repo / 'package.json').write_text(json.dumps({
+                    'name': changes.get('name', 'openclaw'), 'version': changes.get('version', '2026.9.3')}))
+                # This marker must never become checked-out source before admission succeeds.
+                (repo / 'source-marker').write_text('synthetic source')
+                git('add', '.')
+                git('commit', '-m', 'fixture')
+                sha = git('rev-parse', 'HEAD')
+                if changes.get('tag_same'):
+                    git('tag', 'v2026.9.3')
+                if changes.get('branch_advanced') or changes.get('tag_other'):
+                    git('commit', '--allow-empty', '-m', 'later source')
+                    if changes.get('tag_other'):
+                        git('tag', 'v2026.9.3')
+                        git('checkout', '-B', 'release/2026.9.3', sha)
+                bin_dir = root / 'bin'
+                bin_dir.mkdir()
+                shim = bin_dir / 'git'
+                shim.write_text('''#!/usr/bin/env python3
+import os, subprocess, sys
+args = sys.argv[1:]
+args = [os.environ['FIXTURE_REPO'] if a == 'https://github.com/openclaw/openclaw.git' else a for a in args]
+sys.exit(subprocess.call([os.environ['REAL_GIT'], *args]))
+''')
+                shim.chmod(0o755)
+                gh = bin_dir / 'gh'
+                gh.write_text('''#!/usr/bin/env python3
+import os, sys
+if os.environ['API_FAILURE'] == 'true': sys.exit(1)
+print(os.environ['COMMIT_JSON'])
+''')
+                gh.chmod(0o755)
+                commit = {'sha': changes.get('api_sha', sha), 'commit': {'verification': {
+                    'verified': changes.get('signature', True), 'reason': changes.get('reason', 'valid')}}}
+                env = dict(os.environ, PATH=f'{bin_dir}:{os.environ["PATH"]}', REAL_GIT=GIT,
+                           FIXTURE_REPO=str(repo), COMMIT_JSON=json.dumps(commit),
+                           API_FAILURE=str(changes.get('api_failure', False)).lower(),
+                           PRETAG_SOURCE_SHA=changes.get('sha', sha), RELEASE_TAG=changes.get('tag', 'v2026.9.3'),
+                           PUBLIC_RELEASE_BRANCH=changes.get('branch', 'release/2026.9.3'),
+                           WORKFLOW_REF=changes.get('workflow', 'refs/heads/main'),
+                           PREFLIGHT_ONLY=changes.get('preflight', 'true'),
+                           SMOKE_TEST_ONLY=changes.get('smoke', 'false'),
+                           SOURCE_REF=changes.get('source_ref', ''), RESUME_RUN_ID=changes.get('resume', ''))
+                result = subprocess.run(['python3', str(ROOT / 'scripts/checkout-macos-pretag.py')],
+                                        cwd=root, env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+                self.assertEqual((root / 'source/source-marker').exists(), accepted)
+                if accepted:
+                    actual = subprocess.check_output([GIT, '-C', str(root / 'source'), 'rev-parse', 'HEAD'], text=True).strip()
+                    self.assertEqual(actual, sha)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
macOS signing and Swift validation currently wait for the final public tag even when the exact signed release candidate is already frozen. Add an optional `pretag_source_sha` to the existing producer and validator so both can start earlier from trusted `main`, with no tag creation or asset promotion.

The trusted helper checks the exact canonical release branch head, GitHub commit signature verification, and package identity before checking out or executing source. Conflicting source/recovery/smoke/publication inputs fail closed. Normal tagged release checks, signing/notarization, and promotion provenance remain intact. The app embeds the real source SHA: a later changelog-only commit requires a fresh producer build/sign/notarization, while an eventual tag at the unchanged SHA can reuse the successful artifacts.

Validation: all 10 repository test methods passed, including 19 real-Git source-admission scenarios, existing notarization recovery, complete Swift-suite failure propagation, and appcast retention/promotion rejection. Node script syntax and diff checks pass. Independent P2 review is clean (0.94). Hosted CI will exercise Linux and macOS workflow regression suites; no signed release or public asset publication was performed for this change.
