### PR TITLE
ci(npm): enforce the beta floor for core and official plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,15 @@ jobs:
         run: |
           node --check scripts/openclaw-release-evidence.mjs
           node --check scripts/openclaw-release-evidence-from-full-validation.mjs
+          node --check scripts/release-npm-beta-floor.mjs
 
       - name: Run workflow regression tests
         env:
           PYTHONDONTWRITEBYTECODE: "1"
         run: python3 -m unittest discover -s tests -v
+
+      - name: Run script tests
+        run: node --test 'tests/*.test.mjs'
 
       - name: Exercise selected package manager
         working-directory: .git/action-proof/source

--- a/.github/workflows/openclaw-npm-dist-tags.yml
+++ b/.github/workflows/openclaw-npm-dist-tags.yml
@@ -30,7 +30,8 @@ env:
 
 jobs:
   sync_beta_to_stable:
-    if: ${{ github.event_name == 'schedule' || inputs.mode == 'sync_beta_to_stable' }}
+    needs: [promote_beta_to_latest, sync_stable_dist_tags]
+    if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.mode == 'sync_beta_to_stable' || needs.promote_beta_to_latest.outputs.latest_published == 'true' || needs.sync_stable_dist_tags.outputs.latest_published == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,196 +46,73 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout trusted dist-tag tooling
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/release-npm-beta-floor.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Read official plugin inventory
+        uses: actions/checkout@v7
+        with:
+          repository: openclaw/openclaw
+          ref: main
+          path: source
+          persist-credentials: false
+          sparse-checkout: /extensions/*/package.json
+          sparse-checkout-cone-mode: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Resolve npm dist-tag state
-        id: resolve_state
+      - name: Validate latest release tag exists in public repo
         run: |
           set -euo pipefail
-          latest_version="$(npm view openclaw dist-tags.latest)"
-          beta_version="$(npm view openclaw dist-tags.beta)"
-
-          echo "Current latest dist-tag: ${latest_version}"
-          echo "Current beta dist-tag: ${beta_version}"
-
-          if [[ -z "${latest_version}" || -z "${beta_version}" ]]; then
-            echo "Missing npm dist-tag values." >&2
+          release_version="$(npm view openclaw dist-tags.latest --prefer-online)"
+          if [[ ! "$release_version" =~ ^[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+            echo "npm latest must identify a regular stable release." >&2
             exit 1
           fi
+          git ls-remote --exit-code "https://github.com/${OPENCLAW_REPOSITORY}.git" \
+            "refs/tags/v${release_version}" "refs/tags/v${release_version}^{}" >/dev/null
 
-          LATEST_VERSION="${latest_version}" BETA_VERSION="${beta_version}" node <<'NODE' >> "$GITHUB_OUTPUT"
-          const latest = process.env.LATEST_VERSION?.trim() ?? "";
-          const beta = process.env.BETA_VERSION?.trim() ?? "";
-
-          function fail(message) {
-            console.error(message);
-            process.exit(1);
-          }
-
-          function parseRelease(version) {
-            const match = version.match(
-              /^(\d{4})\.(\d+)\.(\d+)(?:-(?:(beta)\.(\d+)|(\d+)))?$/,
-            );
-            if (!match) {
-              return null;
-            }
-            const [, year, month, day, betaMarker, betaNumber, correctionNumber] = match;
-            if (betaMarker) {
-              return {
-                year: Number(year),
-                month: Number(month),
-                day: Number(day),
-                lane: "beta",
-                ordinal: Number(betaNumber),
-              };
-            }
-            if (correctionNumber) {
-              return {
-                year: Number(year),
-                month: Number(month),
-                day: Number(day),
-                lane: "stable",
-                ordinal: Number(correctionNumber),
-              };
-            }
-            return {
-              year: Number(year),
-              month: Number(month),
-              day: Number(day),
-              lane: "stable",
-              ordinal: 0,
-            };
-          }
-
-          function compareRelease(a, b) {
-            for (const key of ["year", "month", "day"]) {
-              if (a[key] !== b[key]) {
-                return a[key] - b[key];
-              }
-            }
-            const laneRank = { beta: 0, stable: 1 };
-            if (laneRank[a.lane] !== laneRank[b.lane]) {
-              return laneRank[a.lane] - laneRank[b.lane];
-            }
-            return a.ordinal - b.ordinal;
-          }
-
-          const latestParsed = parseRelease(latest);
-          const betaParsed = parseRelease(beta);
-
-          if (!latestParsed) {
-            fail(`Could not parse npm latest dist-tag version: ${latest}`);
-          }
-          if (latestParsed.lane !== "stable") {
-            fail(`npm latest must point at a stable release, got ${latest}.`);
-          }
-          if (!betaParsed) {
-            fail(`Could not parse npm beta dist-tag version: ${beta}`);
-          }
-
-          let action = "noop";
-          let reason = "beta_already_matches_latest";
-
-          if (beta !== latest) {
-            const betaVsLatest = compareRelease(betaParsed, latestParsed);
-            if (betaParsed.lane === "beta" && betaVsLatest > 0) {
-              reason = "beta_points_to_newer_prerelease";
-            } else if (betaVsLatest > 0) {
-              reason = "beta_points_to_newer_release";
-            } else {
-              action = "sync";
-              reason = "sync_beta_to_latest_stable";
-            }
-          }
-
-          console.log(`release_version=${latest}`);
-          console.log(`beta_version=${beta}`);
-          console.log(`action=${action}`);
-          console.log(`reason=${reason}`);
-          NODE
-
-      - name: Validate stable release tag exists in public repo
-        if: ${{ steps.resolve_state.outputs.action == 'sync' }}
-        env:
-          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
-        run: |
-          set -euo pipefail
-          RELEASE_TAG="v${RELEASE_VERSION}"
-          if ! git ls-remote --exit-code "https://github.com/${OPENCLAW_REPOSITORY}.git" "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" >/dev/null; then
-            echo "Public release tag ${RELEASE_TAG} not found in ${OPENCLAW_REPOSITORY}." >&2
-            exit 1
-          fi
-
-      - name: Sync beta dist-tag to stable
-        if: ${{ steps.resolve_state.outputs.action == 'sync' }}
+      - name: Enforce beta floor for core and published plugins
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
         run: |
           set -euo pipefail
           if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
             echo "Missing NPM_TOKEN secret." >&2
             exit 1
           fi
-
           npm_userconfig="$(mktemp)"
           trap 'rm -f "${npm_userconfig}"' EXIT
           chmod 0600 "${npm_userconfig}"
           printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${npm_userconfig}"
-          NPM_CONFIG_USERCONFIG="${npm_userconfig}" npm dist-tag add "openclaw@${RELEASE_VERSION}" beta
-
-          synced_beta="$(npm view openclaw dist-tags.beta)"
-          if [[ "${synced_beta}" != "${RELEASE_VERSION}" ]]; then
-            echo "npm beta points at ${synced_beta}, expected ${RELEASE_VERSION} after sync." >&2
-            exit 1
-          fi
-
-          echo "Synced openclaw@${RELEASE_VERSION} to npm beta."
-
-      - name: Skip sync when npm beta should stay as-is
-        if: ${{ steps.resolve_state.outputs.action != 'sync' }}
-        env:
-          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
-          BETA_VERSION: ${{ steps.resolve_state.outputs.beta_version }}
-          REASON: ${{ steps.resolve_state.outputs.reason }}
-        run: |
-          set -euo pipefail
-          echo "No dist-tag change needed."
-          echo "latest=${RELEASE_VERSION}"
-          echo "beta=${BETA_VERSION}"
-          echo "reason=${REASON}"
-
-      - name: Summarize automatic dist-tag sync
-        env:
-          RELEASE_VERSION: ${{ steps.resolve_state.outputs.release_version }}
-          BETA_VERSION: ${{ steps.resolve_state.outputs.beta_version }}
-          ACTION: ${{ steps.resolve_state.outputs.action }}
-          REASON: ${{ steps.resolve_state.outputs.reason }}
-        run: |
-          set -euo pipefail
+          export NPM_CONFIG_USERCONFIG="${npm_userconfig}"
+          export NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+          unset NODE_AUTH_TOKEN
+          npm whoami >/dev/null
           {
-            echo "## npm dist-tag output"
+            echo "## npm beta floor"
             echo
-            echo "- Mode: \`sync_beta_to_stable\`"
-            echo "- npm \`latest\`: \`${RELEASE_VERSION}\`"
-            echo "- npm \`beta\` before run: \`${BETA_VERSION}\`"
-            echo "- Action: \`${ACTION}\`"
-            echo "- Reason: \`${REASON}\`"
-            if [[ "${ACTION}" == "sync" ]]; then
-              echo "- Result: npm \`beta\` now points at this stable version"
-            else
-              echo "- Result: no change"
-            fi
+            echo '```text'
           } >> "$GITHUB_STEP_SUMMARY"
+          floor_rc=0
+          node scripts/release-npm-beta-floor.mjs source 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || floor_rc=$?
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit "$floor_rc"
 
   promote_beta_to_latest:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'promote_beta_to_latest' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      latest_published: ${{ steps.publish_latest.outputs.latest_published }}
     steps:
       - name: Require main workflow ref for promotion
         env:
@@ -298,6 +176,7 @@ jobs:
           fi
 
       - name: Promote beta to latest
+        id: publish_latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
@@ -308,6 +187,7 @@ jobs:
           chmod 0600 "${npm_userconfig}"
           printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${npm_userconfig}"
           NPM_CONFIG_USERCONFIG="${npm_userconfig}" npm dist-tag add "openclaw@${RELEASE_VERSION}" latest
+          echo "latest_published=true" >> "$GITHUB_OUTPUT"
           promoted_latest="$(npm view openclaw dist-tags.latest)"
           if [[ "${promoted_latest}" != "${RELEASE_VERSION}" ]]; then
             echo "npm latest points at ${promoted_latest}, expected ${RELEASE_VERSION} after promotion." >&2
@@ -335,6 +215,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      latest_published: ${{ steps.publish_latest.outputs.latest_published }}
     steps:
       - name: Require main workflow ref for dist-tag sync
         env:
@@ -390,6 +272,7 @@ jobs:
           echo "Current beta dist-tag: $(npm view openclaw dist-tags.beta)"
 
       - name: Sync stable dist-tags
+        id: publish_latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
@@ -400,19 +283,14 @@ jobs:
           chmod 0600 "${npm_userconfig}"
           printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${npm_userconfig}"
           NPM_CONFIG_USERCONFIG="${npm_userconfig}" npm dist-tag add "openclaw@${RELEASE_VERSION}" latest
-          NPM_CONFIG_USERCONFIG="${npm_userconfig}" npm dist-tag add "openclaw@${RELEASE_VERSION}" beta
+          echo "latest_published=true" >> "$GITHUB_OUTPUT"
 
           synced_latest="$(npm view openclaw dist-tags.latest)"
-          synced_beta="$(npm view openclaw dist-tags.beta)"
           if [[ "${synced_latest}" != "${RELEASE_VERSION}" ]]; then
             echo "npm latest points at ${synced_latest}, expected ${RELEASE_VERSION} after sync." >&2
             exit 1
           fi
-          if [[ "${synced_beta}" != "${RELEASE_VERSION}" ]]; then
-            echo "npm beta points at ${synced_beta}, expected ${RELEASE_VERSION} after sync." >&2
-            exit 1
-          fi
-          echo "Synced openclaw@${RELEASE_VERSION} to npm latest and beta."
+          echo "Synced openclaw@${RELEASE_VERSION} to npm latest; the beta floor runs next."
 
       - name: Summarize manual dist-tag sync
         env:
@@ -426,5 +304,5 @@ jobs:
             echo "- Mode: \`sync_stable_dist_tags\`"
             echo "- Release tag: \`${RELEASE_TAG}\`"
             echo "- Version: \`${RELEASE_VERSION}\`"
-            echo "- Result: npm \`latest\` and \`beta\` now point at this stable version"
+            echo "- Result: npm \`latest\` updated; the beta floor runs next"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enforce the npm beta floor for `openclaw` and every published official plugin: run it after any successful `latest` promotion or sync, on manual dispatch, and daily; advance a missing or older `beta` to `latest`, preserve an equal or newer one, and stop overwriting `beta` unconditionally during stable dist-tag sync.
+
 - Start signed macOS artifact preparation and Swift validation from an exact signed release candidate before tagging, while preserving final publication provenance.
 
 - Verify the complete release evidence directory after publication, reject concurrent changes to that directory, and share publication handling between both workflows. Thanks @vincentkoc.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ maintenance, and durable release evidence separate from the product source repo.
   Swift test lane for an existing OpenClaw tag.
 - `.github/workflows/openclaw-macos-publish.yml` prepares and promotes signed
   macOS release artifacts for an existing OpenClaw tag.
-- `.github/workflows/openclaw-npm-dist-tags.yml` reconciles npm dist-tags after
-  package publication.
+- `.github/workflows/openclaw-npm-dist-tags.yml` promotes or syncs npm `latest`
+  for OpenClaw and enforces the beta floor: after every successful `latest`
+  mutation, on manual `sync_beta_to_stable` dispatch, and daily as a backstop,
+  `beta` for `openclaw` and every published official plugin is advanced to at
+  least its own `latest`; an equal or newer `beta` is preserved. The plugin
+  inventory is read as data from `openclaw/openclaw` `main` manifests.
 - `.github/workflows/openclaw-release-evidence.yml` records manually supplied
   release proof runs.
 - `.github/workflows/openclaw-release-evidence-from-full-validation.yml` ingests
@@ -109,7 +113,9 @@ build step. Run local checks with Node.js 24 and Python 3:
 ```bash
 node --check scripts/openclaw-release-evidence.mjs
 node --check scripts/openclaw-release-evidence-from-full-validation.mjs
+node --check scripts/release-npm-beta-floor.mjs
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
+node --test 'tests/*.test.mjs'
 ```
 
 ## Release Approval

--- a/scripts/release-npm-beta-floor.mjs
+++ b/scripts/release-npm-beta-floor.mjs
@@ -1,0 +1,148 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function parseVersion(version) {
+  const match =
+    typeof version === "string" &&
+    version.match(
+      /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/,
+    );
+  if (!match) throw new Error(`Invalid npm version: ${JSON.stringify(version)}`);
+  const prerelease = match[4]?.split(".") ?? [];
+  if (prerelease.some((part) => /^0\d+$/.test(part))) {
+    throw new Error(`Invalid npm prerelease: ${version}`);
+  }
+  return { core: match.slice(1, 4).map(BigInt), prerelease };
+}
+
+function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i] !== b.core[i]) return a.core[i] < b.core[i] ? -1 : 1;
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    return a.prerelease.length === b.prerelease.length ? 0 : a.prerelease.length === 0 ? 1 : -1;
+  }
+  for (let i = 0; i < Math.max(a.prerelease.length, b.prerelease.length); i++) {
+    const x = a.prerelease[i];
+    const y = b.prerelease[i];
+    if (x === y) continue;
+    if (x === undefined || y === undefined) return x === undefined ? -1 : 1;
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn !== yn) return xn ? -1 : 1;
+    return (xn ? BigInt(x) < BigInt(y) : x < y) ? -1 : 1;
+  }
+  return 0;
+}
+
+export function betaFloorTarget(tags) {
+  if (!tags || typeof tags !== "object" || Array.isArray(tags)) {
+    throw new Error("npm dist-tags must be an object.");
+  }
+  if (tags.latest === undefined) return undefined;
+  parseVersion(tags.latest);
+  return tags.beta === undefined || compareVersions(tags.beta, tags.latest) < 0
+    ? tags.latest
+    : undefined;
+}
+
+function npm(args) {
+  return execFileSync("npm", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 120_000,
+    maxBuffer: 1024 * 1024,
+  }).trim();
+}
+
+function readTags(packageName) {
+  let raw;
+  try {
+    raw = npm(["view", packageName, "dist-tags", "--json", "--prefer-online"]);
+  } catch (error) {
+    if (typeof error.stdout === "string") {
+      let result;
+      try {
+        result = JSON.parse(error.stdout);
+      } catch {
+        /* Report the npm failure below. */
+      }
+      if (result?.error?.code === "E404" && packageName !== "openclaw") return undefined;
+    }
+    throw error;
+  }
+  const parsed = JSON.parse(raw);
+  // npm 12 wraps single-package `view --json` output in a one-element array.
+  return Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
+}
+
+function packageNames(sourceDir) {
+  const packages = new Set(["openclaw"]);
+  const extensions = resolve(sourceDir, "extensions");
+  // Read source manifests as data; never execute source code with the npm token.
+  for (const entry of readdirSync(extensions, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    let raw;
+    try {
+      raw = readFileSync(resolve(extensions, entry.name, "package.json"), "utf8");
+    } catch (error) {
+      if (error.code === "ENOENT") continue;
+      throw error;
+    }
+    const pkg = JSON.parse(raw);
+    if (pkg.openclaw?.release?.publishToNpm !== true || pkg.openclaw?.build?.bundledDist === true)
+      continue;
+    if (
+      pkg.private === true ||
+      typeof pkg.name !== "string" ||
+      !/^@openclaw\/[a-z0-9][a-z0-9._-]*$/.test(pkg.name)
+    ) {
+      throw new Error(`Invalid publishable plugin manifest: ${entry.name}`);
+    }
+    packages.add(pkg.name);
+  }
+  return [...packages].sort();
+}
+
+function main() {
+  if (process.argv.length !== 3)
+    throw new Error("Usage: node scripts/release-npm-beta-floor.mjs <source-dir>");
+  const failures = [];
+  for (const packageName of packageNames(process.argv[2])) {
+    try {
+      const tags = readTags(packageName);
+      if (tags === undefined || tags.latest === undefined) {
+        if (packageName === "openclaw") throw new Error("npm latest is missing.");
+        console.log(`${packageName}: no published latest; skipped`);
+        continue;
+      }
+      const target = betaFloorTarget(tags);
+      if (target === undefined) {
+        console.log(`${packageName}: beta=${tags.beta} >= latest=${tags.latest}; unchanged`);
+        continue;
+      }
+      npm(["dist-tag", "add", `${packageName}@${target}`, "beta"]);
+      const readback = readTags(packageName);
+      if (!readback || readback.latest === undefined || betaFloorTarget(readback) !== undefined) {
+        throw new Error("beta floor did not converge after mutation.");
+      }
+      console.log(`${packageName}: beta ${tags.beta ?? "<missing>"} -> ${target}`);
+    } catch (error) {
+      failures.push(`${packageName}: ${error.message}`);
+    }
+  }
+  if (failures.length > 0) throw new Error(failures.join("\n"));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tests/release-npm-beta-floor.test.mjs
+++ b/tests/release-npm-beta-floor.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { betaFloorTarget } from "../scripts/release-npm-beta-floor.mjs";
+
+const SCRIPT = fileURLToPath(new URL("../scripts/release-npm-beta-floor.mjs", import.meta.url));
+
+for (const [label, beta, expected] of [
+  ["missing", undefined, "2026.9.3"],
+  ["older same-train prerelease", "2026.9.3-beta.1", "2026.9.3"],
+  ["older final", "2026.9.1", "2026.9.3"],
+  ["equal", "2026.9.3", undefined],
+  ["newer next-train prerelease", "2026.9.4-beta.1", undefined],
+]) {
+  test(label, () => {
+    const tags = Object.freeze({
+      latest: "2026.9.3",
+      beta,
+      alpha: "2026.9.5-alpha.1",
+      "extended-stable": "2026.8.33",
+    });
+    assert.equal(betaFloorTarget(tags), expected);
+  });
+}
+
+test("compares prerelease identifiers numerically and ignores build metadata", () => {
+  assert.equal(
+    betaFloorTarget({ latest: "2026.9.3-beta.10", beta: "2026.9.3-beta.9" }),
+    "2026.9.3-beta.10",
+  );
+  assert.equal(betaFloorTarget({ latest: "2026.9.3+one", beta: "2026.9.3+two" }), undefined);
+});
+
+test("rejects malformed versions and skips packages with no latest", () => {
+  assert.throws(
+    () => betaFloorTarget({ latest: "2026.9.3", beta: "broken" }),
+    /Invalid npm version/,
+  );
+  assert.throws(
+    () => betaFloorTarget({ latest: "2026.9.3", beta: "2026.9.3-beta.01" }),
+    /Invalid npm prerelease/,
+  );
+  assert.equal(betaFloorTarget({ beta: "2026.9.4-beta.1" }), undefined);
+});
+
+// Fake npm on PATH: serves dist-tags from a JSON state file in the npm 11 object
+// shape or the npm 12 one-element array shape, records every invocation, and
+// mutates state on `dist-tag add` unless the package is listed as failing or stale.
+const FAKE_NPM = `#!/usr/bin/env node
+const fs = require("node:fs");
+const state = JSON.parse(fs.readFileSync(process.env.FAKE_NPM_STATE, "utf8"));
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_NPM_CALLS, args.join(" ") + "\\n");
+if (args[0] === "view" && args[2] === "dist-tags" && args.includes("--json")) {
+  const tags = state.registry[args[1]];
+  if (!tags) {
+    process.stdout.write(JSON.stringify({ error: { code: "E404", summary: "Not Found" } }));
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(state.shape === "array" ? [tags] : tags));
+  process.exit(0);
+}
+if (args[0] === "dist-tag" && args[1] === "add" && args[3] === "beta") {
+  const at = args[2].lastIndexOf("@");
+  const name = args[2].slice(0, at);
+  if ((state.failAdd || []).includes(name)) {
+    process.stderr.write("npm error code E403\\n");
+    process.exit(1);
+  }
+  if (!(state.staleReadback || []).includes(name)) {
+    state.registry[name].beta = args[2].slice(at + 1);
+    fs.writeFileSync(process.env.FAKE_NPM_STATE, JSON.stringify(state));
+  }
+  process.exit(0);
+}
+process.stderr.write("unexpected npm invocation\\n");
+process.exit(2);
+`;
+
+// Official inventory fixture: a bundledDist:false plugin, a plugin without the
+// bundledDist key, a deferred (bundledDist:true) plugin, a core-only extension,
+// and a directory without a manifest.
+const OFFICIAL_MANIFESTS = {
+  alpha: {},
+  bravo: { openclaw: { release: { publishToNpm: true } } },
+  deferred: { openclaw: { release: { publishToNpm: true }, build: { bundledDist: true } } },
+  internal: { openclaw: {} },
+  "no-manifest": null,
+};
+
+function runFloor({ registry, shape = "object", failAdd, staleReadback, manifests = OFFICIAL_MANIFESTS }) {
+  const root = mkdtempSync(join(tmpdir(), "beta-floor-"));
+  try {
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    writeFileSync(join(bin, "npm"), FAKE_NPM);
+    chmodSync(join(bin, "npm"), 0o755);
+    const source = join(root, "source");
+    for (const [name, extra] of Object.entries(manifests)) {
+      const dir = join(source, "extensions", name);
+      mkdirSync(dir, { recursive: true });
+      if (extra === null) continue;
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({
+          name: `@openclaw/${name}`,
+          version: "2026.9.3",
+          openclaw: { release: { publishToNpm: true }, build: { bundledDist: false } },
+          ...extra,
+        }),
+      );
+    }
+    const statePath = join(root, "state.json");
+    writeFileSync(statePath, JSON.stringify({ registry, shape, failAdd, staleReadback }));
+    const callsPath = join(root, "calls.log");
+    writeFileSync(callsPath, "");
+    const result = { code: 0, stdout: "", stderr: "" };
+    try {
+      result.stdout = execFileSync(process.execPath, [SCRIPT, source], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          PATH: [bin, dirname(process.execPath), process.env.PATH].join(delimiter),
+          FAKE_NPM_STATE: statePath,
+          FAKE_NPM_CALLS: callsPath,
+        },
+      });
+    } catch (error) {
+      Object.assign(result, { code: error.status, stdout: error.stdout, stderr: error.stderr });
+    }
+    result.registry = JSON.parse(readFileSync(statePath, "utf8")).registry;
+    result.calls = readFileSync(callsPath, "utf8").trim().split("\n").filter(Boolean);
+    return result;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+for (const shape of ["object", "array"]) {
+  test(`advances only lagging betas across core and published plugins (npm ${shape} output)`, () => {
+    const result = runFloor({
+      shape,
+      registry: {
+        openclaw: { latest: "2026.9.3", beta: "2026.9.1" },
+        "@openclaw/alpha": { latest: "2026.9.3", beta: "2026.9.4-beta.1" },
+      },
+    });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.registry.openclaw.beta, "2026.9.3");
+    assert.equal(result.registry["@openclaw/alpha"].beta, "2026.9.4-beta.1");
+    assert.deepEqual(
+      result.calls.filter((call) => call.startsWith("dist-tag ")),
+      ["dist-tag add openclaw@2026.9.3 beta"],
+    );
+    assert.deepEqual(
+      result.calls.filter((call) => /deferred|internal|no-manifest/.test(call)),
+      [],
+    );
+    for (const line of [
+      "@openclaw/alpha: beta=2026.9.4-beta.1 >= latest=2026.9.3; unchanged",
+      "@openclaw/bravo: no published latest; skipped",
+      "openclaw: beta 2026.9.1 -> 2026.9.3",
+    ]) {
+      assert.match(result.stdout, new RegExp(`^${line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+    }
+  });
+}
+
+test("keeps checking every package and reports all failures together", () => {
+  const result = runFloor({
+    failAdd: ["@openclaw/alpha"],
+    registry: {
+      openclaw: { beta: "2026.9.1" },
+      "@openclaw/alpha": { latest: "2026.9.3", beta: "2026.9.1" },
+    },
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /^@openclaw\/alpha: /m);
+  assert.match(result.stderr, /^openclaw: npm latest is missing\.$/m);
+  assert.match(result.stdout, /^@openclaw\/bravo: no published latest; skipped$/m);
+  assert.equal(result.registry["@openclaw/alpha"].beta, "2026.9.1");
+});
+
+test("fails when the registry does not converge after the mutation", () => {
+  const result = runFloor({
+    staleReadback: ["openclaw"],
+    registry: {
+      openclaw: { latest: "2026.9.3", beta: "2026.9.1" },
+      "@openclaw/alpha": { latest: "2026.9.3", beta: "2026.9.3" },
+    },
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /^openclaw: beta floor did not converge after mutation\.$/m);
+  assert.ok(result.calls.includes("dist-tag add openclaw@2026.9.3 beta"));
+});
+
+test("rejects an invalid publishable manifest before touching the registry", () => {
+  const result = runFloor({
+    manifests: { alpha: { private: true } },
+    registry: { openclaw: { latest: "2026.9.3", beta: "2026.9.3" } },
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /^Invalid publishable plugin manifest: alpha$/m);
+  assert.deepEqual(result.calls, []);
+});


### PR DESCRIPTION
## Problem

Peter's rule for the npm channels: `beta` must never be older than `latest`. The 2026-09-10 update campaign found 93 stale `beta` tags (core plus 92 official plugin packages) after `2026.9.3` shipped to `latest`, so beta-pinned installs could downgrade behind stable.

The ledger's daily `sync_beta_to_stable` job only covered the `openclaw` package, and `sync_stable_dist_tags` overwrote `beta` unconditionally, which would also clobber a newer next-train beta. The scheduled run https://github.com/openclaw/releases/actions/runs/34314815043 additionally failed with npm `E401` because `NPM_TOKEN` had died; that secret is rotated separately (rerun attempt 2 is green).

## Solution

`sync_beta_to_stable` is now the beta floor:

- runs on the daily schedule, on manual `sync_beta_to_stable` dispatch, and immediately after a successful `latest` mutation from `promote_beta_to_latest` or `sync_stable_dist_tags` in the same run (`needs` + `latest_published` outputs, `!cancelled()` so skipped producers do not block it)
- reads `extensions/*/package.json` from `openclaw/openclaw` `main` as data only (sparse checkout, `persist-credentials: false`, nothing executed), selecting `publishToNpm: true` manifests that are not `bundledDist: true`, matching the source collector's deferred-publication rule
- `scripts/release-npm-beta-floor.mjs` checks `openclaw` plus every selected plugin against its own `latest`: a missing or semver-older `beta` is advanced to `latest`, an equal or newer `beta` is preserved, unpublished plugins (E404) are skipped, every mutation is verified by readback, and failures are aggregated per package instead of aborting on the first one
- `npm whoami` runs before any mutation so a dead token fails fast; the token only ever lives in a `mktemp` userconfig
- normalizes npm 12's one-element-array `view --json` output (npm 11 returns an object)
- `sync_stable_dist_tags` no longer force-sets `beta`; the floor runs next and decides
- per-package decisions land in the step summary

## Impact

Every `latest` mutation in this repository is followed by a floor check in the same run; source-repo publishes to `latest` are caught by the daily backstop or a manual dispatch. Newer betas are never rolled back. No publisher workflow or credential handling changes beyond the existing `NPM_TOKEN` secret.

## Evidence

- `node --test 'tests/*.test.mjs'`: 12 passed. Decision table (missing, older same-train prerelease, older final, equal, newer next-train prerelease, prerelease numeric ordering, build metadata, malformed input) plus end-to-end runs of the real script against a fake `npm` on `PATH`: advances only lagging betas across core and plugins for both npm output shapes, never queries deferred/internal/manifest-less extensions, keeps checking after a package fails and reports all failures together, fails on non-converging readback, and rejects an invalid manifest before any registry call.
- The npm 12 array-shape case fails without the normalization and passes with it.
- `node --check scripts/release-npm-beta-floor.mjs`, `git diff --check`: clean.
- `python3 -m unittest discover -s tests`: 8 pass; the 2 `test_macos_pretag` errors are local-only (they pass with `GIT_CONFIG_GLOBAL=/dev/null`; my global tag-signing config breaks `git tag` in the temp repo) and unrelated to this change.
- Live npm 12.0.2 and 11.19.0 read-only queries confirmed the `dist-tags --json` and `E404 --json` shapes the reader relies on. No registry tags were changed by this PR.
