### PR TITLE
fix(npm): wait for beta floor readback to converge

### DIFF
--- a/scripts/release-npm-beta-floor.mjs
+++ b/scripts/release-npm-beta-floor.mjs
@@ -80,6 +80,20 @@ function readTags(packageName) {
   return Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
 }
 
+const READBACK_ATTEMPTS = 10;
+const READBACK_DELAY_MS = 3_000;
+
+// A successful dist-tag mutation can lag the registry's read path by several
+// seconds (observed live on 2026-09-10), so verify convergence within a bounded window.
+async function readConvergedTags(packageName) {
+  for (let attempt = 1; ; attempt++) {
+    const tags = readTags(packageName);
+    if (tags?.latest !== undefined && betaFloorTarget(tags) === undefined) return tags;
+    if (attempt === READBACK_ATTEMPTS) throw new Error("beta floor did not converge after mutation.");
+    await new Promise((resolve) => setTimeout(resolve, READBACK_DELAY_MS));
+  }
+}
+
 function packageNames(sourceDir) {
   const packages = new Set(["openclaw"]);
   const extensions = resolve(sourceDir, "extensions");
@@ -108,7 +122,7 @@ function packageNames(sourceDir) {
   return [...packages].sort();
 }
 
-function main() {
+async function main() {
   if (process.argv.length !== 3)
     throw new Error("Usage: node scripts/release-npm-beta-floor.mjs <source-dir>");
   const failures = [];
@@ -126,10 +140,7 @@ function main() {
         continue;
       }
       npm(["dist-tag", "add", `${packageName}@${target}`, "beta"]);
-      const readback = readTags(packageName);
-      if (!readback || readback.latest === undefined || betaFloorTarget(readback) !== undefined) {
-        throw new Error("beta floor did not converge after mutation.");
-      }
+      await readConvergedTags(packageName);
       console.log(`${packageName}: beta ${tags.beta ?? "<missing>"} -> ${target}`);
     } catch (error) {
       failures.push(`${packageName}: ${error.message}`);
@@ -139,10 +150,8 @@ function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
-  try {
-    main();
-  } catch (error) {
+  main().catch((error) => {
     console.error(error.message);
     process.exitCode = 1;
-  }
+  });
 }

--- a/tests/release-npm-beta-floor.test.mjs
+++ b/tests/release-npm-beta-floor.test.mjs
@@ -49,14 +49,21 @@ test("rejects malformed versions and skips packages with no latest", () => {
 
 // Fake npm on PATH: serves dist-tags from a JSON state file in the npm 11 object
 // shape or the npm 12 one-element array shape, records every invocation, and
-// mutates state on `dist-tag add` unless the package is listed as failing or stale.
+// mutates state on `dist-tag add` unless the package is listed as failing or stale,
+// and can serve a fixed number of stale reads after a mutation before converging.
 const FAKE_NPM = `#!/usr/bin/env node
 const fs = require("node:fs");
 const state = JSON.parse(fs.readFileSync(process.env.FAKE_NPM_STATE, "utf8"));
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.FAKE_NPM_CALLS, args.join(" ") + "\\n");
 if (args[0] === "view" && args[2] === "dist-tags" && args.includes("--json")) {
-  const tags = state.registry[args[1]];
+  let tags = state.registry[args[1]];
+  const stale = (state.stale || {})[args[1]];
+  if (stale && stale.remaining > 0) {
+    stale.remaining -= 1;
+    fs.writeFileSync(process.env.FAKE_NPM_STATE, JSON.stringify(state));
+    tags = stale.tags;
+  }
   if (!tags) {
     process.stdout.write(JSON.stringify({ error: { code: "E404", summary: "Not Found" } }));
     process.exit(1);
@@ -72,6 +79,9 @@ if (args[0] === "dist-tag" && args[1] === "add" && args[3] === "beta") {
     process.exit(1);
   }
   if (!(state.staleReadback || []).includes(name)) {
+    if (state.staleReads) {
+      state.stale = { ...(state.stale || {}), [name]: { remaining: state.staleReads, tags: { ...state.registry[name] } } };
+    }
     state.registry[name].beta = args[2].slice(at + 1);
     fs.writeFileSync(process.env.FAKE_NPM_STATE, JSON.stringify(state));
   }
@@ -92,7 +102,14 @@ const OFFICIAL_MANIFESTS = {
   "no-manifest": null,
 };
 
-function runFloor({ registry, shape = "object", failAdd, staleReadback, manifests = OFFICIAL_MANIFESTS }) {
+function runFloor({
+  registry,
+  shape = "object",
+  failAdd,
+  staleReadback,
+  staleReads,
+  manifests = OFFICIAL_MANIFESTS,
+}) {
   const root = mkdtempSync(join(tmpdir(), "beta-floor-"));
   try {
     const bin = join(root, "bin");
@@ -115,7 +132,7 @@ function runFloor({ registry, shape = "object", failAdd, staleReadback, manifest
       );
     }
     const statePath = join(root, "state.json");
-    writeFileSync(statePath, JSON.stringify({ registry, shape, failAdd, staleReadback }));
+    writeFileSync(statePath, JSON.stringify({ registry, shape, failAdd, staleReadback, staleReads }));
     const callsPath = join(root, "calls.log");
     writeFileSync(callsPath, "");
     const result = { code: 0, stdout: "", stderr: "" };
@@ -186,6 +203,23 @@ test("keeps checking every package and reports all failures together", () => {
   assert.equal(result.registry["@openclaw/alpha"].beta, "2026.9.1");
 });
 
+test("waits for a lagging registry read to converge after the mutation", () => {
+  const result = runFloor({
+    staleReads: 2,
+    registry: {
+      openclaw: { latest: "2026.9.3", beta: "2026.9.1" },
+      "@openclaw/alpha": { latest: "2026.9.3", beta: "2026.9.3" },
+    },
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.registry.openclaw.beta, "2026.9.3");
+  assert.match(result.stdout, /^openclaw: beta 2026.9.1 -> 2026.9.3$/m);
+  assert.equal(
+    result.calls.filter((call) => call === "view openclaw dist-tags --json --prefer-online").length,
+    4,
+  );
+});
+
 test("fails when the registry does not converge after the mutation", () => {
   const result = runFloor({
     staleReadback: ["openclaw"],
@@ -197,6 +231,10 @@ test("fails when the registry does not converge after the mutation", () => {
   assert.equal(result.code, 1);
   assert.match(result.stderr, /^openclaw: beta floor did not converge after mutation\.$/m);
   assert.ok(result.calls.includes("dist-tag add openclaw@2026.9.3 beta"));
+  assert.equal(
+    result.calls.filter((call) => call === "view openclaw dist-tags --json --prefer-online").length,
+    11,
+  );
 });
 
 test("rejects an invalid publishable manifest before touching the registry", () => {


### PR DESCRIPTION
## Problem

During the first live run of the landed beta floor (#25), advancing `@openclaw/team-reports@2026.9.3` to `beta` by hand succeeded on npm's side, but `npm view … dist-tags --prefer-online` still returned the old tags for several seconds afterwards. The script's immediate post-mutation readback would have reported `beta floor did not converge after mutation.` and failed the run even though the registry was correct.

## Solution

`main()` is now async and verifies convergence within a bounded window: up to 10 readbacks, 3 s apart, before recording the failure. Per-package aggregation, the non-zero exit, and the entry-point error handling are unchanged.

## Evidence

- `node --test 'tests/*.test.mjs'`: 13 passed. New case: the fake registry serves two stale reads after the mutation and the run converges (4 reads of that package total). The existing never-converges case now also asserts exactly 11 reads (1 decision + 10 bounded attempts) before the failure is reported.
- `node --check scripts/release-npm-beta-floor.mjs`, `git diff --check`: clean.
- Live context: run https://github.com/openclaw/releases/actions/runs/34438508315 (green, 91 packages unchanged) ran after the hand repair; the lag was observed on the manual `dist-tag add` readback that preceded it. Unattended writes from CI still need a granular npm token (session tokens get `EOTP`), tracked separately.
